### PR TITLE
Changes to allow compilation on Windows 

### DIFF
--- a/sep.pyx
+++ b/sep.pyx
@@ -194,9 +194,9 @@ cdef int _get_sep_dtype(dtype) except -1:
         return SEP_TFLOAT
     elif t is np.bool_ or t is np.ubyte:
         return SEP_TBYTE
-    elif t == np.double:
+    elif dtype == np.double:
         return SEP_TDOUBLE
-    elif t == np.intc:
+    elif dtype == np.intc:
         return SEP_TINT
     raise ValueError('input array dtype not supported: {0}'.format(dtype))
 

--- a/src/aper.c
+++ b/src/aper.c
@@ -35,6 +35,17 @@
 #define WINPOS_STEPMIN  0.0001  /* Minimum change in position for continuing */
 #define WINPOS_FAC      2.0     /* Centroid offset factor (2 for a Gaussian) */
 
+/*
+  Adding (void *) pointers is a GNU C extension, not part of standard C. 
+  When compiling on Windows with MS VIsual C compiler need to cast the
+  (void *) to something the size of one byte.
+*/
+#if defined(_MSC_VER)
+  #define MSVC_VOID_CAST (char *)
+#else
+  #define MSVC_VOID_CAST
+#endif
+
 /****************************************************************************/
 /* conversions between ellipse representations */
 
@@ -394,11 +405,11 @@ int sep_sum_circann_multi(void *data, void *error, void *mask,
     {
       /* set pointers to the start of this row */
       pos = (iy%h) * w + xmin;
-      datat = data + pos*size;
+      datat = MSVC_VOID_CAST data + pos*size;
       if (errisarray)
-        errort = error + pos*esize;
+        errort = MSVC_VOID_CAST error + pos*esize;
       if (mask)
-        maskt = mask + pos*msize;
+        maskt = MSVC_VOID_CAST mask + pos*msize;
 
       /* loop over pixels in this row */
       for (ix=xmin; ix<xmax; ix++)
@@ -609,9 +620,9 @@ int sep_kron_radius(void *data, void *mask, int dtype, int mdtype,
     {
       /* set pointers to the start of this row */
       pos = (iy%h) * w + xmin;
-      datat = data + pos*size;
+      datat = MSVC_VOID_CAST data + pos*size;
       if (mask)
-        maskt = mask + pos*msize;
+        maskt = MSVC_VOID_CAST mask + pos*msize;
 
       /* loop over pixels in this row */
       for (ix=xmin; ix<xmax; ix++)
@@ -792,11 +803,11 @@ int sep_windowed(void *data, void *error, void *mask,
         {
           /* set pointers to the start of this row */
           pos = (iy%h) * w + xmin;
-          datat = data + pos*size;
+          datat = MSVC_VOID_CAST data + pos*size;
           if (errisarray)
-            errort = error + pos*esize;
+            errort = MSVC_VOID_CAST error + pos*esize;
           if (mask)
-            maskt = mask + pos*msize;
+            maskt = MSVC_VOID_CAST mask + pos*msize;
 
           /* loop over pixels in this row */
           for (ix=xmin; ix<xmax; ix++)

--- a/src/aperbody.c.inc
+++ b/src/aperbody.c.inc
@@ -1,3 +1,14 @@
+/*
+	Adding (void *) pointers is a GNU C extension, not part of standard C. 
+	When compiling on Windows with MS Visual C compiler need to cast the
+	(void *) to something the size of one byte.
+*/
+#if defined(_MSC_VER)
+	#define MSVC_VOID_CAST (char *)
+#else
+  	#define MSVC_VOID_CAST
+#endif
+
 int APER_NAME(void *data, void *error, void *mask,
 	      int dtype, int edtype, int mdtype, int w, int h,
 	      double maskthresh, double gain, short inflag,
@@ -63,11 +74,11 @@ int APER_NAME(void *data, void *error, void *mask,
     {
       /* set pointers to the start of this row */
       pos = (iy%h) * w + xmin;
-      datat = data + pos*size;
+      datat = MSVC_VOID_CAST data + pos*size;
       if (errisarray)
-	errort = error + pos*esize;
+	errort = MSVC_VOID_CAST error + pos*esize;
       if (mask)
-	maskt = mask + pos*msize;
+	maskt = MSVC_VOID_CAST mask + pos*msize;
 
       /* loop over pixels in this row */
       for (ix=xmin; ix<xmax; ix++)

--- a/src/overlap.h
+++ b/src/overlap.h
@@ -5,9 +5,15 @@
  * Original cython version by Thomas Robitaille. Converted to C by Kyle
  * Barbary. */
 
+#if defined(_MSC_VER)
+  #define INLINE _inline
+#else
+  #define INLINE inline
+#endif
+
 /* Return area of a circle arc between (x1, y1) and (x2, y2) with radius r */
 /* reference: http://mathworld.wolfram.com/CircularSegment.html */
-static inline double area_arc(double x1, double y1, double x2, double y2,
+static INLINE double area_arc(double x1, double y1, double x2, double y2,
 			      double r)
 {
   double a, theta;
@@ -18,7 +24,7 @@ static inline double area_arc(double x1, double y1, double x2, double y2,
 }
 
 /* Area of a triangle defined by three verticies */
-static inline double area_triangle(double x1, double y1, double x2, double y2,
+static INLINE double area_triangle(double x1, double y1, double x2, double y2,
 				   double x3, double y3)
 {
   return 0.5 * fabs(x1*(y2-y3) + x2*(y3-y1) + x3*(y1-y2));
@@ -28,7 +34,7 @@ static inline double area_triangle(double x1, double y1, double x2, double y2,
  * Assumes that xmax >= xmin >= 0.0, ymax >= ymin >= 0.0.
  * (can always modify input to conform to this).
  */
-static inline double circoverlap_core(double xmin, double ymin,
+static INLINE double circoverlap_core(double xmin, double ymin,
 				      double xmax, double ymax, double r)
 {
   double a, b, x1, x2, y1, y2, r2, xmin2, ymin2, xmax2, ymax2;
@@ -181,7 +187,7 @@ typedef struct
   point p1, p2;
 } intersections;
 
-static inline void swap(double *a, double *b)
+static INLINE void swap(double *a, double *b)
 {
   double temp;
   temp = *a;
@@ -189,7 +195,7 @@ static inline void swap(double *a, double *b)
   *b = temp;
 }
 
-static inline void swap_point(point *a, point *b)
+static INLINE void swap_point(point *a, point *b)
 {
   point temp;
   temp = *a;
@@ -198,7 +204,7 @@ static inline void swap_point(point *a, point *b)
 }
 
 /* rotate values to the left: a=b, b=c, c=a */
-static inline void rotate(double *a, double *b, double *c)
+static INLINE void rotate(double *a, double *b, double *c)
 {
   double temp;
   temp = *a;


### PR DESCRIPTION
This is *almost* ready to go. I ran the test and I get one fail, at least: there is one extra src detected on Windows that is not detected in the reference file (and is not detected on mac).

As far as I can tell it is probably safe to ignore...since the detected "source" is essentially noise (see image below) and the rest of the source positions match. On the other hand, you could argue the detection result should be identical. Not sure how to handle it.

When I run the tests on my mac I also get a fail in the comparison to sextractor results, but I'll open a separate issue for that.

<img width="500" alt="result_of_image_fits__600___and_desktop" src="https://cloud.githubusercontent.com/assets/1147167/12060310/6330c8ee-af32-11e5-8793-242b35ca6706.png">