### PR TITLE
Handle sources out of the image returning NaNs.

### DIFF
--- a/sep.pyx
+++ b/sep.pyx
@@ -952,9 +952,10 @@ def sum_circle(np.ndarray data not None, x, y, r,
                 1, SEP_MASK_IGNORE, &bkgflux, &bkgfluxerr, &bkgarea, &bkgflag)
             _assert_ok(status)
 
-            flux1 -= bkgflux / bkgarea * area1
-            bkgfluxerr = bkgfluxerr / bkgarea * area1
-            fluxerr1 = sqrt(fluxerr1*fluxerr1 + bkgfluxerr*bkgfluxerr)
+            if area1 > 0:
+              flux1 -= bkgflux / bkgarea * area1
+              bkgfluxerr = bkgfluxerr / bkgarea * area1
+              fluxerr1 = sqrt(fluxerr1*fluxerr1 + bkgfluxerr*bkgfluxerr)
             (<double*>np.PyArray_MultiIter_DATA(it, 5))[0] = flux1
             (<double*>np.PyArray_MultiIter_DATA(it, 6))[0] = fluxerr1
             (<short*>np.PyArray_MultiIter_DATA(it, 7))[0] = flag1
@@ -1222,9 +1223,10 @@ def sum_ellipse(np.ndarray data not None, x, y, a, b, theta, r=1.0,
                 subpix, 0, &bkgflux, &bkgfluxerr, &bkgarea, &bkgflag)
             _assert_ok(status)
 
-            flux1 -= bkgflux / bkgarea * area1
-            bkgfluxerr = bkgfluxerr / bkgarea * area1
-            fluxerr1 = sqrt(fluxerr1*fluxerr1 + bkgfluxerr*bkgfluxerr)
+            if area1 > 0:
+              flux1 -= bkgflux / bkgarea * area1
+              bkgfluxerr = bkgfluxerr / bkgarea * area1
+              fluxerr1 = sqrt(fluxerr1*fluxerr1 + bkgfluxerr*bkgfluxerr)
 
             (<double*>np.PyArray_MultiIter_DATA(it, 8))[0] = flux1
             (<double*>np.PyArray_MultiIter_DATA(it, 9))[0] = fluxerr1

--- a/src/aperture.i
+++ b/src/aperture.i
@@ -1,5 +1,5 @@
 /*
-	Adding (void *) pointers is a GNU C extension, not part of standard C.
+	Adding (void *) pointers is a GNU C extension, not part of standard C. 
 	When compiling on Windows with MS Visual C compiler need to cast the
 	(void *) to something the size of one byte.
 */
@@ -113,7 +113,7 @@ int APER_NAME(sep_image *im,
 	      else
 		/* definitely fully in aperture */
 		overlap = 1.0;
-
+	      
 	      pix = convert(datat);
 
 	      if (errisarray)
@@ -124,7 +124,7 @@ int APER_NAME(sep_image *im,
 		}
 
 	      if (im->mask && (mconvert(maskt) > im->maskthresh))
-		{
+		{ 
 		  *flag |= SEP_APER_HASMASKED;
 		  maskarea += overlap;
 		}
@@ -137,7 +137,7 @@ int APER_NAME(sep_image *im,
 	      totarea += overlap;
 
 	    } /* closes "if pixel might be within aperture" */
-
+	  
 	  /* increment pointers by one element */
 	  datat += size;
 	  if (errisarray)
@@ -162,16 +162,8 @@ int APER_NAME(sep_image *im,
   if (im->gain > 0.0 && tv>0.0)
     sigtv += tv / im->gain;
 
-  if (totarea > 0.0)
-  {
-    *sum = tv;
-    *sumerr = sqrt(sigtv);
-  }
-  else
-  {
-    *sum = NAN;
-    *sumerr = NAN;
-  }
+  *sum = tv;
+  *sumerr = sqrt(sigtv);
   *area = totarea;
 
   return status;

--- a/src/aperture.i
+++ b/src/aperture.i
@@ -1,5 +1,5 @@
 /*
-	Adding (void *) pointers is a GNU C extension, not part of standard C. 
+	Adding (void *) pointers is a GNU C extension, not part of standard C.
 	When compiling on Windows with MS Visual C compiler need to cast the
 	(void *) to something the size of one byte.
 */
@@ -113,7 +113,7 @@ int APER_NAME(sep_image *im,
 	      else
 		/* definitely fully in aperture */
 		overlap = 1.0;
-	      
+
 	      pix = convert(datat);
 
 	      if (errisarray)
@@ -124,7 +124,7 @@ int APER_NAME(sep_image *im,
 		}
 
 	      if (im->mask && (mconvert(maskt) > im->maskthresh))
-		{ 
+		{
 		  *flag |= SEP_APER_HASMASKED;
 		  maskarea += overlap;
 		}
@@ -137,7 +137,7 @@ int APER_NAME(sep_image *im,
 	      totarea += overlap;
 
 	    } /* closes "if pixel might be within aperture" */
-	  
+
 	  /* increment pointers by one element */
 	  datat += size;
 	  if (errisarray)
@@ -162,8 +162,16 @@ int APER_NAME(sep_image *im,
   if (im->gain > 0.0 && tv>0.0)
     sigtv += tv / im->gain;
 
-  *sum = tv;
-  *sumerr = sqrt(sigtv);
+  if (totarea > 0.0)
+  {
+    *sum = tv;
+    *sumerr = sqrt(sigtv);
+  }
+  else
+  {
+    *sum = NAN;
+    *sumerr = NAN;
+  }
   *area = totarea;
 
   return status;


### PR DESCRIPTION
These small fixes in the code should be able to deal with sources out of the image, which have `area1 == 0.0`. This means that ANY photometry did with an aperture entirely out of the image will return NaN.