### PR TITLE
Add segmentation masking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,13 @@ matrix:
         - os: osx
           env: LANG=c
         - env: LANG=python PYTHON_VERSION=2.6 NUMPY_VERSION=1.9
-        - env: LANG=python PYTHON_VERSION=2.7 NUMPY_VERSION=1.6
         - env: LANG=python PYTHON_VERSION=2.7 NUMPY_VERSION=1.7
         - env: LANG=python PYTHON_VERSION=2.7 NUMPY_VERSION=1.8
         - env: LANG=python PYTHON_VERSION=2.7 NUMPY_VERSION=1.9
         - env: LANG=python PYTHON_VERSION=3.3 NUMPY_VERSION=1.9
         - env: LANG=python PYTHON_VERSION=3.4 NUMPY_VERSION=1.9
+        - env: LANG=python PYTHON_VERSION=3.5 NUMPY_VERSION=1.14
+        - env: LANG=python PYTHON_VERSION=3.6 NUMPY_VERSION=1.16
         - os: osx
           env: LANG=python PYTHON_VERSION=2.7 NUMPY_VERSION=1.9
                MINICONDA_URL=http://repo.continuum.io/miniconda/Miniconda-3.7.3-MacOSX-x86_64.sh

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+v1.10.0 (20 March 2019)
+=======================
+
+* Add segmentation masking to the photometry and kron/auto functions (#69).
+
 v1.0.3 (12 June 2018)
 =====================
 

--- a/ctest/test_image.c
+++ b/ctest/test_image.c
@@ -272,7 +272,7 @@ int main(int argc, char **argv)
 
   /* background estimation */
   t0 = gettime_ns();
-  sep_image im = {data, NULL, NULL, SEP_TFLOAT, 0, 0, nx, ny, 0.0, SEP_NOISE_NONE, 1.0, 0.0};
+  sep_image im = {data, NULL, NULL, NULL, SEP_TFLOAT, 0, 0, 0, nx, ny, 0.0, SEP_NOISE_NONE, 1.0, 0.0};
   status = sep_background(&im, 64, 64, 3, 3, 0.0, &bkg);
   t1 = gettime_ns();
   if (status) goto exit;

--- a/ctest/test_image.c
+++ b/ctest/test_image.c
@@ -315,7 +315,7 @@ int main(int argc, char **argv)
   t0 = gettime_ns();
   for (i=0; i<catalog->nobj; i++, fluxt++, fluxerrt++, flagt++, areat++)
     sep_sum_circle(&im,
-		   catalog->x[i], catalog->y[i], 5.0, 5, 0,
+		   catalog->x[i], catalog->y[i], 5.0, 0, 5, 0,
 		   fluxt, fluxerrt, areat, flagt);
   t1 = gettime_ns();
   printf("sep_sum_circle() [r= 5.0]  %6.3f us/aperture\n",
@@ -333,7 +333,7 @@ int main(int argc, char **argv)
   for (i=0; i<catalog->nobj; i++)
     {
       fprintf(catout, "%3d %#11.7g %#11.7g %#11.7g %#11.7g\n",
-	      i, catalog->x[i], catalog->y[i], flux[i], fluxerr[i]);
+	      i+1, catalog->x[i], catalog->y[i], flux[i], fluxerr[i]);
     }
   fclose(catout);
 

--- a/docs/apertures.rst
+++ b/docs/apertures.rst
@@ -169,7 +169,7 @@ SourceExtractor provides a mechanism for measuring the "AUTO" and "FLUX_RADIUS" 
 For example, using a segmentation array provided by ``sep.extract``, we can compute the masked ``flux_radius`` that could otherwise be artificially large due to flux from nearby sources::
 
     # list of object id numbers that correspond to the segments
-    objs['id'] = np.arange(len(objs), dtype=np.int32)
+    objs['id'] = np.arange(1, len(objs)+1, dtype=np.int32)
     
     r, flag = sep.flux_radius(data, objs['x'], objs['y'], 6.*objs['a'], 0.5,
                               seg_id=objs['id'], seg=seg, 

--- a/docs/apertures.rst
+++ b/docs/apertures.rst
@@ -169,10 +169,10 @@ SourceExtractor provides a mechanism for measuring the "AUTO" and "FLUX_RADIUS" 
 For example, using a segmentation array provided by ``sep.extract``, we can compute the masked ``flux_radius`` that could otherwise be artificially large due to flux from nearby sources::
 
     # list of object id numbers that correspond to the segments
-    objs['id'] = np.arange(1, len(objs)+1, dtype=np.int32)
+    seg_id = np.arange(1, len(objs)+1, dtype=np.int32)
     
     r, flag = sep.flux_radius(data, objs['x'], objs['y'], 6.*objs['a'], 0.5,
-                              seg_id=objs['id'], seg=seg, 
+                              seg_id=seg_id, seg=seg, 
                               normflux=flux, subpix=5)
 
 To enforce that a given measurement **only** includes pixels within a segment, provide negative values in the ``seg_id`` list.  Otherwise the mask for a given object will be pixels with ``(seg == 0) | (seg_id == id_i)``.

--- a/docs/apertures.rst
+++ b/docs/apertures.rst
@@ -161,6 +161,24 @@ of 0.5 and a normalizing flux of ``FLUX_AUTO``. The equivalent here is::
     xwin, ywin, flag = sep.winpos(data, objs['x'], objs['y'], sig)
 
 
+Segmentation-masked image measurements
+--------------------------------------
+
+SourceExtractor provides a mechanism for measuring the "AUTO" and "FLUX_RADIUS" parameters for a given object including a mask for neighboring sources.  In addition to the mask, setting the SourceExtractor parameter ``MASK_TYPE=CORRECT`` further fills the masked pixels of a given source with "good" pixel values reflected opposite of the masked pixels.  The ``SEP`` photometry and measurement functions provide an option for simple masking without reflection or subtracting neighbor flux.  
+
+For example, using a segmentation array provided by ``sep.extract``, we can compute the masked ``flux_radius`` that could otherwise be artificially large due to flux from nearby sources::
+
+    # list of object id numbers that correspond to the segments
+    objs['id'] = np.arange(len(objs), dtype=np.int32)
+    
+    r, flag = sep.flux_radius(data, objs['x'], objs['y'], 6.*objs['a'], 0.5,
+                              seg_id=objs['id'], seg=seg, 
+                              normflux=flux, subpix=5)
+
+To enforce that a given measurement **only** includes pixels within a segment, provide negative values in the ``seg_id`` list.  Otherwise the mask for a given object will be pixels with ``(seg == 0) | (seg_id == id_i)``.
+
+The following functions include the segmentation masking: ``sum_circle``, ``sum_circann``, ``sum_ellipse``, ``sum_ellipann``, ``flux_radius`` , and ``kron_radius`` (``winpos`` **currently does not**). 
+
 Masking image regions
 ---------------------
 

--- a/sep.pyx
+++ b/sep.pyx
@@ -15,7 +15,7 @@ from cpython.version cimport PY_MAJOR_VERSION
 
 np.import_array()  # To access the numpy C-API.
 
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 
 # -----------------------------------------------------------------------------
 # Definitions from the SEP C library
@@ -857,6 +857,16 @@ def sum_circle(np.ndarray data not None, x, y, r,
     maskthresh : float, optional
         Threshold for a pixel to be masked. Default is ``0.0``.
 
+    seg : `numpy.ndarray`, optional
+        Segmentation image with dimensions of `data` and dtype `np.float32`.
+    
+    seg_id : array_like, optional
+        Array of segmentation ids that correspond to the dimensions of `x` 
+        and `y`.  If the values in seg_id are negative, then the mask is 
+        generated requiring pixels within the segment.  Otherwise, mask 
+        pixels in `seg` with nonzero values different from `seg_id` for a 
+        given object in the list.  Must be provided along with `seg`.
+        
     bkgann : tuple, optional
         Length 2 tuple giving the inner and outer radius of a
         "background annulus". If supplied, the background is estimated
@@ -1007,10 +1017,10 @@ def sum_circle(np.ndarray data not None, x, y, r,
 @cython.wraparound(False)
 def sum_circann(np.ndarray data not None, x, y, rin, rout,
                 var=None, err=None, gain=None, np.ndarray mask=None,
-                seg_id=None, np.ndarray seg=None, 
-                double maskthresh=0.0, int subpix=5):
+                double maskthresh=0.0, seg_id=None, np.ndarray seg=None, 
+                int subpix=5):
     """sum_circann(data, x, y, rin, rout, err=None, var=None, mask=None,
-                   maskthresh=0.0, gain=None, subpix=5)
+                   maskthresh=0.0, seg_id=None, seg=None, gain=None, subpix=5)
 
     Sum data in circular annular aperture(s).
 
@@ -1037,6 +1047,16 @@ def sum_circann(np.ndarray data not None, x, y, rin, rout,
     maskthresh : float, optional
         Threshold for a pixel to be masked. Default is ``0.0``.
 
+    seg : `numpy.ndarray`, optional
+        Segmentation image with dimensions of `data` and dtype `np.float32`.
+    
+    seg_id : array_like, optional
+        Array of segmentation ids that correspond to the dimensions of `x` 
+        and `y`.  If the values in seg_id are negative, then the mask is 
+        generated requiring pixels within the segment.  Otherwise, mask 
+        pixels in `seg` with nonzero values different from `seg_id` for a 
+        given object in the list.  Must be provided along with `seg`.
+            
     gain : float, optional
         Conversion factor between data array units and poisson counts,
         used in calculating poisson noise in aperture sum. If ``None``
@@ -1121,8 +1141,9 @@ def sum_circann(np.ndarray data not None, x, y, rin, rout,
 
 def sum_ellipse(np.ndarray data not None, x, y, a, b, theta, r=1.0,
                 var=None, err=None, gain=None, np.ndarray mask=None,
+                double maskthresh=0.0, 
                 seg_id=None, np.ndarray seg=None, 
-                double maskthresh=0.0, bkgann=None, int subpix=5):
+                bkgann=None, int subpix=5):
     """sum_ellipse(data, x, y, a, b, theta, r, err=None, var=None, mask=None,
                    maskthresh=0.0, bkgann=None, gain=None, subpix=5)
 
@@ -1164,6 +1185,16 @@ def sum_ellipse(np.ndarray data not None, x, y, a, b, theta, r=1.0,
     maskthresh : float, optional
         Threshold for a pixel to be masked. Default is ``0.0``.
 
+    seg : `numpy.ndarray`, optional
+        Segmentation image with dimensions of `data` and dtype `np.float32`.
+    
+    seg_id : array_like, optional
+        Array of segmentation ids that correspond to the dimensions of `x` 
+        and `y`.  If the values in seg_id are negative, then the mask is 
+        generated requiring pixels within the segment.  Otherwise, mask 
+        pixels in `seg` with nonzero values different from `seg_id` for a 
+        given object in the list.  Must be provided along with `seg`.
+    
     bkgann : tuple, optional
         Length 2 tuple giving the inner and outer radius of a
         "background annulus". If supplied, the background is estimated
@@ -1319,8 +1350,9 @@ def sum_ellipse(np.ndarray data not None, x, y, a, b, theta, r=1.0,
 @cython.wraparound(False)
 def sum_ellipann(np.ndarray data not None, x, y, a, b, theta, rin, rout,
                  var=None, err=None, gain=None, np.ndarray mask=None,
+                 double maskthresh=0.0, 
                  seg_id=None, np.ndarray seg=None, 
-                 double maskthresh=0.0, int subpix=5):
+                 int subpix=5):
     """sum_ellipann(data, x, y, a, b, theta, rin, rout, err=None, var=None,
                     mask=None, maskthresh=0.0, gain=None, subpix=5)
 
@@ -1361,6 +1393,16 @@ def sum_ellipann(np.ndarray data not None, x, y, a, b, theta, rin, rout,
         used in calculating poisson noise in aperture sum. If ``None``
         (default), do not add poisson noise.
 
+    seg : `numpy.ndarray`, optional
+        Segmentation image with dimensions of `data` and dtype `np.float32`.
+    
+    seg_id : array_like, optional
+        Array of segmentation ids that correspond to the dimensions of `x` 
+        and `y`.  If the values in seg_id are negative, then the mask is 
+        generated requiring pixels within the segment.  Otherwise, mask 
+        pixels in `seg` with nonzero values different from `seg_id` for a 
+        given object in the list.  Must be provided along with `seg`.
+            
     subpix : int, optional
         Subpixel sampling factor. Default is 5.
 
@@ -1484,6 +1526,16 @@ def flux_radius(np.ndarray data not None, x, y, rmax, frac, normflux=None,
     maskthresh : float, optional
         Threshold for a pixel to be masked. Default is ``0.0``.
 
+    seg : `numpy.ndarray`, optional
+        Segmentation image with dimensions of `data` and dtype `np.float32`.
+    
+    seg_id : array_like, optional
+        Array of segmentation ids that correspond to the dimensions of `x` 
+        and `y`.  If the values in seg_id are negative, then the mask is 
+        generated requiring pixels within the segment.  Otherwise, mask 
+        pixels in `seg` with nonzero values different from `seg_id` for a 
+        given object in the list.  Must be provided along with `seg`.
+    
     subpix : int, optional
         Subpixel sampling factor. Default is 5.
 
@@ -1678,10 +1730,9 @@ def mask_ellipse(np.ndarray arr not None, x, y, a=None, b=None, theta=None,
 
 
 def kron_radius(np.ndarray data not None, x, y, a, b, theta, r,
-                np.ndarray mask=None, 
-                seg_id=None, np.ndarray seg=None, 
-                double maskthresh=0.0):
-    """kron_radius(data, x, y, a, b, theta, r, mask=None, maskthresh=0.0)
+                np.ndarray mask=None, double maskthresh=0.0,
+                seg_id=None, np.ndarray seg=None):
+    """kron_radius(data, x, y, a, b, theta, r, mask=None, maskthresh=0.0, seg_id=None, seg=None)
 
     Calculate Kron "radius" within an ellipse.
 
@@ -1723,7 +1774,17 @@ def kron_radius(np.ndarray data not None, x, y, a, b, theta, r,
 
     maskthresh : float, optional
         Pixels with mask > maskthresh will be ignored.
-
+    
+    seg : `numpy.ndarray`, optional
+        Segmentation image with dimensions of `data` and dtype `np.float32`.
+    
+    seg_id : array_like, optional
+        Array of segmentation ids that correspond to the dimensions of `x` 
+        and `y`.  If the values in seg_id are negative, then the mask is 
+        generated requiring pixels within the segment.  Otherwise, mask 
+        pixels in `seg` with nonzero values different from `seg_id` for a 
+        given object in the list.  Must be provided along with `seg`.
+            
     Returns
     -------
     kronrad : array_like

--- a/sep.pyx
+++ b/sep.pyx
@@ -15,7 +15,7 @@ from cpython.version cimport PY_MAJOR_VERSION
 
 np.import_array()  # To access the numpy C-API.
 
-__version__ = "1.0.4"
+__version__ = "1.10.0"
 
 # -----------------------------------------------------------------------------
 # Definitions from the SEP C library

--- a/sep.pyx
+++ b/sep.pyx
@@ -857,17 +857,21 @@ def sum_circle(np.ndarray data not None, x, y, r,
     maskthresh : float, optional
         Threshold for a pixel to be masked. Default is ``0.0``.
 
-    segmap : `numpy.ndarray`, optional
-        Segmentation image with dimensions of `data` and dtype `np.int32`.
+    segmap : `~numpy.ndarray`, optional
+        Segmentation image with dimensions of ``data`` and dtype ``np.int32``.
         This is an optional input and corresponds to the segmentation map
         output by `~sep.extract`.
-    
+            
     seg_id : array_like, optional
-        Array of segmentation ids that correspond to the dimensions of `x` 
-        and `y`.  If the values in seg_id are negative, then the mask is 
-        generated requiring pixels within the segment.  Otherwise, mask 
-        pixels in `segmap` with nonzero values different from `seg_id` for a 
-        given object in the list.  Must be provided along with `segmap`.
+        Array of segmentation ids used to mask additional pixels in the image.
+        Dimensions correspond to the dimensions of ``x`` and ``y``. The
+        behavior differs depending on whether ``seg_id`` is negative or
+        positive. If ``seg_id`` is positive, all pixels belonging to other
+        objects are masked. (Pixel ``j, i`` is masked if ``seg[j, i] != seg_id
+        and seg[j, i] != 0``). If ``seg_id`` is negative, all pixels other
+        than those belonging to the object of interest are masked. (Pixel ``j,
+        i`` is masked if ``seg[j, i] != -seg_id``).  NB: must be included if 
+        ``segmap` is provided.
         
     bkgann : tuple, optional
         Length 2 tuple giving the inner and outer radius of a
@@ -1050,17 +1054,21 @@ def sum_circann(np.ndarray data not None, x, y, rin, rout,
     maskthresh : float, optional
         Threshold for a pixel to be masked. Default is ``0.0``.
 
-    segmap : `numpy.ndarray`, optional
-        Segmentation image with dimensions of `data` and dtype `np.int32`.
+    segmap : `~numpy.ndarray`, optional
+        Segmentation image with dimensions of ``data`` and dtype ``np.int32``.
         This is an optional input and corresponds to the segmentation map
         output by `~sep.extract`.
             
     seg_id : array_like, optional
-        Array of segmentation ids that correspond to the dimensions of `x` 
-        and `y`.  If the values in seg_id are negative, then the mask is 
-        generated requiring pixels within the segment.  Otherwise, mask 
-        pixels in `segmap` with nonzero values different from `seg_id` for a 
-        given object in the list.  Must be provided along with `segmap`.
+        Array of segmentation ids used to mask additional pixels in the image.
+        Dimensions correspond to the dimensions of ``x`` and ``y``. The
+        behavior differs depending on whether ``seg_id`` is negative or
+        positive. If ``seg_id`` is positive, all pixels belonging to other
+        objects are masked. (Pixel ``j, i`` is masked if ``seg[j, i] != seg_id
+        and seg[j, i] != 0``). If ``seg_id`` is negative, all pixels other
+        than those belonging to the object of interest are masked. (Pixel ``j,
+        i`` is masked if ``seg[j, i] != -seg_id``).  NB: must be included if 
+        ``segmap` is provided.
             
     gain : float, optional
         Conversion factor between data array units and poisson counts,
@@ -1191,17 +1199,21 @@ def sum_ellipse(np.ndarray data not None, x, y, a, b, theta, r=1.0,
     maskthresh : float, optional
         Threshold for a pixel to be masked. Default is ``0.0``.
 
-    segmap : `numpy.ndarray`, optional
-        Segmentation image with dimensions of `data` and dtype `np.int32`.
+    segmap : `~numpy.ndarray`, optional
+        Segmentation image with dimensions of ``data`` and dtype ``np.int32``.
         This is an optional input and corresponds to the segmentation map
         output by `~sep.extract`.
             
     seg_id : array_like, optional
-        Array of segmentation ids that correspond to the dimensions of `x` 
-        and `y`.  If the values in seg_id are negative, then the mask is 
-        generated requiring pixels within the segment.  Otherwise, mask 
-        pixels in `segmap` with nonzero values different from `seg_id` for a 
-        given object in the list.  Must be provided along with `segmap`.
+        Array of segmentation ids used to mask additional pixels in the image.
+        Dimensions correspond to the dimensions of ``x`` and ``y``. The
+        behavior differs depending on whether ``seg_id`` is negative or
+        positive. If ``seg_id`` is positive, all pixels belonging to other
+        objects are masked. (Pixel ``j, i`` is masked if ``seg[j, i] != seg_id
+        and seg[j, i] != 0``). If ``seg_id`` is negative, all pixels other
+        than those belonging to the object of interest are masked. (Pixel ``j,
+        i`` is masked if ``seg[j, i] != -seg_id``).  NB: must be included if 
+        ``segmap` is provided.
     
     bkgann : tuple, optional
         Length 2 tuple giving the inner and outer radius of a
@@ -1401,18 +1413,22 @@ def sum_ellipann(np.ndarray data not None, x, y, a, b, theta, rin, rout,
         used in calculating poisson noise in aperture sum. If ``None``
         (default), do not add poisson noise.
 
-    segmap : `numpy.ndarray`, optional
-        Segmentation image with dimensions of `data` and dtype `np.int32`.
+    segmap : `~numpy.ndarray`, optional
+        Segmentation image with dimensions of ``data`` and dtype ``np.int32``.
         This is an optional input and corresponds to the segmentation map
         output by `~sep.extract`.
             
     seg_id : array_like, optional
-        Array of segmentation ids that correspond to the dimensions of `x` 
-        and `y`.  If the values in seg_id are negative, then the mask is 
-        generated requiring pixels within the segment.  Otherwise, mask 
-        pixels in `segmap` with nonzero values different from `seg_id` for a 
-        given object in the list.  Must be provided along with `segmap`.
-            
+        Array of segmentation ids used to mask additional pixels in the image.
+        Dimensions correspond to the dimensions of ``x`` and ``y``. The
+        behavior differs depending on whether ``seg_id`` is negative or
+        positive. If ``seg_id`` is positive, all pixels belonging to other
+        objects are masked. (Pixel ``j, i`` is masked if ``seg[j, i] != seg_id
+        and seg[j, i] != 0``). If ``seg_id`` is negative, all pixels other
+        than those belonging to the object of interest are masked. (Pixel ``j,
+        i`` is masked if ``seg[j, i] != -seg_id``).  NB: must be included if 
+        ``segmap` is provided.
+    
     subpix : int, optional
         Subpixel sampling factor. Default is 5.
 
@@ -1536,18 +1552,22 @@ def flux_radius(np.ndarray data not None, x, y, rmax, frac, normflux=None,
     maskthresh : float, optional
         Threshold for a pixel to be masked. Default is ``0.0``.
 
-    segmap : `numpy.ndarray`, optional
-        Segmentation image with dimensions of `data` and dtype `np.int32`.
+    segmap : `~numpy.ndarray`, optional
+        Segmentation image with dimensions of ``data`` and dtype ``np.int32``.
         This is an optional input and corresponds to the segmentation map
         output by `~sep.extract`.
             
     seg_id : array_like, optional
-        Array of segmentation ids that correspond to the dimensions of `x` 
-        and `y`.  If the values in seg_id are negative, then the mask is 
-        generated requiring pixels within the segment.  Otherwise, mask 
-        pixels in `segmap` with nonzero values different from `seg_id` for a 
-        given object in the list.  Must be provided along with `segmap`.
-    
+        Array of segmentation ids used to mask additional pixels in the image.
+        Dimensions correspond to the dimensions of ``x`` and ``y``. The
+        behavior differs depending on whether ``seg_id`` is negative or
+        positive. If ``seg_id`` is positive, all pixels belonging to other
+        objects are masked. (Pixel ``j, i`` is masked if ``seg[j, i] != seg_id
+        and seg[j, i] != 0``). If ``seg_id`` is negative, all pixels other
+        than those belonging to the object of interest are masked. (Pixel ``j,
+        i`` is masked if ``seg[j, i] != -seg_id``).  NB: must be included if 
+        ``segmap` is provided.
+        
     subpix : int, optional
         Subpixel sampling factor. Default is 5.
 
@@ -1787,17 +1807,21 @@ def kron_radius(np.ndarray data not None, x, y, a, b, theta, r,
     maskthresh : float, optional
         Pixels with mask > maskthresh will be ignored.
     
-    segmap : `numpy.ndarray`, optional
-        Segmentation image with dimensions of `data` and dtype `np.int32`.
+    segmap : `~numpy.ndarray`, optional
+        Segmentation image with dimensions of ``data`` and dtype ``np.int32``.
         This is an optional input and corresponds to the segmentation map
         output by `~sep.extract`.
             
     seg_id : array_like, optional
-        Array of segmentation ids that correspond to the dimensions of `x` 
-        and `y`.  If the values in seg_id are negative, then the mask is 
-        generated requiring pixels within the segment.  Otherwise, mask 
-        pixels in `segmap` with nonzero values different from `seg_id` for a 
-        given object in the list.  Must be provided along with `segmap`.
+        Array of segmentation ids used to mask additional pixels in the image.
+        Dimensions correspond to the dimensions of ``x`` and ``y``. The
+        behavior differs depending on whether ``seg_id`` is negative or
+        positive. If ``seg_id`` is positive, all pixels belonging to other
+        objects are masked. (Pixel ``j, i`` is masked if ``seg[j, i] != seg_id
+        and seg[j, i] != 0``). If ``seg_id`` is negative, all pixels other
+        than those belonging to the object of interest are masked. (Pixel ``j,
+        i`` is masked if ``seg[j, i] != -seg_id``).  NB: must be included if 
+        ``segmap` is provided.
             
     Returns
     -------

--- a/sep.pyx
+++ b/sep.pyx
@@ -911,7 +911,7 @@ def sum_circle(np.ndarray data not None, x, y, r,
             
     # Test for map without seg_id.  Nothing happens if seg_id supplied but 
     # without segmap.
-    if (segmap is not None) & (seg_id is None):
+    if (segmap is not None) and (seg_id is None):
         raise ValueError('`segmap` supplied but not `seg_id`.')
         
     _parse_arrays(data, err, var, mask, segmap, &im)
@@ -1098,7 +1098,7 @@ def sum_circann(np.ndarray data not None, x, y, rin, rout,
 
     # Test for segmap without seg_id.  Nothing happens if seg_id supplied but 
     # without segmap.
-    if (segmap is not None) & (seg_id is None):
+    if (segmap is not None) and (seg_id is None):
         raise ValueError('`segmap` supplied but not `seg_id`.')
         
     _parse_arrays(data, err, var, mask, segmap, &im)
@@ -1253,7 +1253,7 @@ def sum_ellipse(np.ndarray data not None, x, y, a, b, theta, r=1.0,
 
     # Test for seg without seg_id.  Nothing happens if seg_id supplied but 
     # without segmap.
-    if (segmap is not None) & (seg_id is None):
+    if (segmap is not None) and (seg_id is None):
         raise ValueError('`segmap` supplied but not `seg_id`.')
         
     _parse_arrays(data, err, var, mask, segmap, &im)
@@ -1454,7 +1454,7 @@ def sum_ellipann(np.ndarray data not None, x, y, a, b, theta, rin, rout,
 
     # Test for segmap without seg_id.  Nothing happens if seg_id supplied but 
     # without segmap.
-    if (segmap is not None) & (seg_id is None):
+    if (segmap is not None) and (seg_id is None):
         raise ValueError('`segmap` supplied but not `seg_id`.')
         
     _parse_arrays(data, err, var, mask, segmap, &im)
@@ -1602,7 +1602,7 @@ def flux_radius(np.ndarray data not None, x, y, rmax, frac, normflux=None,
 
     # Test for segmap without seg_id.  Nothing happens if seg_id supplied but 
     # without segmap.
-    if (segmap is not None) & (seg_id is None):
+    if (segmap is not None) and (seg_id is None):
         raise ValueError('`segmap` supplied but not `seg_id`.')
         
     _parse_arrays(data, None, None, mask, segmap, &im)
@@ -1839,7 +1839,7 @@ def kron_radius(np.ndarray data not None, x, y, a, b, theta, r,
 
     # Test for segmap without seg_id.  Nothing happens if seg_id supplied but 
     # without segmap.
-    if (segmap is not None) & (seg_id is None):
+    if (segmap is not None) and (seg_id is None):
         raise ValueError('`segmap` supplied but not `seg_id`.')
         
     _parse_arrays(data, None, None, mask, segmap, &im)

--- a/sep.pyx
+++ b/sep.pyx
@@ -1145,7 +1145,8 @@ def sum_ellipse(np.ndarray data not None, x, y, a, b, theta, r=1.0,
                 seg_id=None, np.ndarray seg=None, 
                 bkgann=None, int subpix=5):
     """sum_ellipse(data, x, y, a, b, theta, r, err=None, var=None, mask=None,
-                   maskthresh=0.0, bkgann=None, gain=None, subpix=5)
+                   maskthresh=0.0, seg_id=None, seg=None, bkgann=None, 
+                   gain=None, subpix=5)
 
     Sum data in elliptical aperture(s).
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Astronomy",
     "Intended Audience :: Science/Research"]
 
-setup(name="sep",
+setup(name="sepx",
       version=version,
       description=description,
       long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Astronomy",
     "Intended Audience :: Science/Research"]
 
-setup(name="sepx",
+setup(name="sep",
       version=version,
       description=description,
       long_description=long_description,

--- a/src/aperture.c
+++ b/src/aperture.c
@@ -383,7 +383,7 @@ int sep_sum_circann_multi(sep_image *im,
     return status;
   if (im->mask && (status = get_converter(im->mdtype, &mconvert, &msize)))
     return status;
-  if (im->seg && (status = get_converter(im->sdtype, &sconvert, &ssize)))
+  if (im->segmap && (status = get_converter(im->sdtype, &sconvert, &ssize)))
     return status;
 
   /* get image noise */
@@ -417,8 +417,8 @@ int sep_sum_circann_multi(sep_image *im,
         errort = MSVC_VOID_CAST im->noise + pos*esize;
       if (im->mask)
         maskt = MSVC_VOID_CAST im->mask + pos*msize;
-      if (im->seg)
-        segt = MSVC_VOID_CAST im->seg + pos*ssize;
+      if (im->segmap)
+        segt = MSVC_VOID_CAST im->segmap + pos*ssize;
 
       /* loop over pixels in this row */
       for (ix=xmin; ix<xmax; ix++)
@@ -456,7 +456,7 @@ int sep_sum_circann_multi(sep_image *im,
     	           not equal to `id`.
 
     	      */ 
-    	      if (im->seg)
+    	      if (im->segmap)
       	        {
       	          if (id > 0) 
       	            {
@@ -644,7 +644,7 @@ int sep_kron_radius(sep_image *im, double x, double y,
     return status;
   if (im->mask && (status = get_converter(im->mdtype, &mconvert, &msize)))
       return status;
-  if (im->seg && (status = get_converter(im->sdtype, &sconvert, &ssize)))
+  if (im->segmap && (status = get_converter(im->sdtype, &sconvert, &ssize)))
       return status;
 
   /* get extent of ellipse in x and y */
@@ -659,8 +659,8 @@ int sep_kron_radius(sep_image *im, double x, double y,
       datat = MSVC_VOID_CAST im->data + pos*size;
       if (im->mask)
         maskt = MSVC_VOID_CAST im->mask + pos*msize;
-      if (im->seg)
-        segt = MSVC_VOID_CAST im->seg + pos*ssize;
+      if (im->segmap)
+        segt = MSVC_VOID_CAST im->segmap + pos*ssize;
 
       /* loop over pixels in this row */
       for (ix=xmin; ix<xmax; ix++)
@@ -684,7 +684,7 @@ int sep_kron_radius(sep_image *im, double x, double y,
     	           not equal to `id`.
 
     	      */ 
-    	      if (im->seg)
+    	      if (im->segmap)
       	        {
       	          if (id > 0) 
       	            {

--- a/src/aperture.i
+++ b/src/aperture.i
@@ -51,7 +51,7 @@ int APER_NAME(sep_image *im,
   if (im->mask && (status = get_converter(im->mdtype, &mconvert, &msize)))
     return status;
 
-  if (im->seg && (status = get_converter(im->sdtype, &sconvert, &ssize)))
+  if (im->segmap && (status = get_converter(im->sdtype, &sconvert, &ssize)))
     return status;
       
   /* get image noise */
@@ -83,8 +83,8 @@ int APER_NAME(sep_image *im,
 	errort = MSVC_VOID_CAST im->noise + pos*esize;
       if (im->mask)
 	maskt = MSVC_VOID_CAST im->mask + pos*msize;
-      if (im->seg)
-  	segt = MSVC_VOID_CAST im->seg + pos*ssize;
+      if (im->segmap)
+  	segt = MSVC_VOID_CAST im->segmap + pos*ssize;
   	
       /* loop over pixels in this row */
       for (ix=xmin; ix<xmax; ix++)
@@ -144,7 +144,7 @@ int APER_NAME(sep_image *im,
 	           not equal to `id`.
 	           
 	      */ 
-	      if (im->seg)
+	      if (im->segmap)
   	        {
   	          if (id > 0) 
   	            {

--- a/src/aperture.i
+++ b/src/aperture.i
@@ -10,17 +10,18 @@
 #endif
 
 int APER_NAME(sep_image *im,
-	      double x, double y, APER_ARGS, int subpix, short inflag,
+	      double x, double y, APER_ARGS, int id, int subpix, short inflag,
 	      double *sum, double *sumerr, double *area, short *flag)
 {
   PIXTYPE pix, varpix;
   double dx, dy, dx1, dy2, offset, scale, scale2, tmp;
   double tv, sigtv, totarea, maskarea, overlap, rpix2;
-  int ix, iy, xmin, xmax, ymin, ymax, sx, sy, status, size, esize, msize;
+  int ix, iy, xmin, xmax, ymin, ymax, sx, sy, status, size, esize, msize, ssize;
+  int ismasked;
   long pos;
   short errisarray, errisstd;
-  BYTE *datat, *errort, *maskt;
-  converter convert, econvert, mconvert;
+  BYTE *datat, *errort, *maskt, *segt;
+  converter convert, econvert, mconvert, sconvert;
   APER_DECL;
 
   /* input checks */
@@ -29,10 +30,10 @@ int APER_NAME(sep_image *im,
     return ILLEGAL_SUBPIX;
 
   /* initializations */
-  size = esize = msize = 0;
+  size = esize = msize = ssize = 0;
   tv = sigtv = 0.0;
   overlap = totarea = maskarea = 0.0;
-  datat = maskt = NULL;
+  datat = maskt = segt = NULL;
   errort = im->noise;
   *flag = 0;
   varpix = 0.0;
@@ -50,6 +51,9 @@ int APER_NAME(sep_image *im,
   if (im->mask && (status = get_converter(im->mdtype, &mconvert, &msize)))
     return status;
 
+  if (im->seg && (status = get_converter(im->sdtype, &sconvert, &ssize)))
+    return status;
+      
   /* get image noise */
   if (im->noise_type != SEP_NOISE_NONE)
     {
@@ -68,7 +72,7 @@ int APER_NAME(sep_image *im,
 
   /* get extent of box */
   APER_BOXEXTENT;
-
+  
   /* loop over rows in the box */
   for (iy=ymin; iy<ymax; iy++)
     {
@@ -79,7 +83,9 @@ int APER_NAME(sep_image *im,
 	errort = MSVC_VOID_CAST im->noise + pos*esize;
       if (im->mask)
 	maskt = MSVC_VOID_CAST im->mask + pos*msize;
-
+      if (im->seg)
+  	segt = MSVC_VOID_CAST im->seg + pos*ssize;
+  	
       /* loop over pixels in this row */
       for (ix=xmin; ix<xmax; ix++)
 	{
@@ -122,9 +128,40 @@ int APER_NAME(sep_image *im,
 		  if (errisstd)
 		    varpix *= varpix;
 		}
-
+              
+              ismasked = 0;
 	      if (im->mask && (mconvert(maskt) > im->maskthresh))
-		{ 
+	        {
+	          ismasked = 1;
+	        }
+	      
+	      /* Segmentation image:  
+	           
+	           If `id` is negative, require segmented pixels within the 
+	           aperture.
+	           
+	           If `id` is positive, mask pixels with nonzero segment ids
+	           not equal to `id`.
+	           
+	      */ 
+	      if (im->seg)
+  	        {
+  	          if (id > 0) 
+  	            {
+  	              if ((sconvert(segt) > 0.) & (sconvert(segt) != id))
+  	                {
+  	                  ismasked = 1;
+  	                }
+  	            } else {
+	              if (sconvert(segt) != -1*id)
+	                {
+	                  ismasked = 1;
+	                }  	            
+  	            }
+  	        }
+  	      
+	      if (ismasked > 0) 
+	      	{ 
 		  *flag |= SEP_APER_HASMASKED;
 		  maskarea += overlap;
 		}
@@ -143,6 +180,7 @@ int APER_NAME(sep_image *im,
 	  if (errisarray)
 	    errort += esize;
 	  maskt += msize;
+	  segt += ssize;
 	}
     }
 

--- a/src/sep.h
+++ b/src/sep.h
@@ -63,9 +63,11 @@ typedef struct {
   void *data;        /* data array                */
   void *noise;       /* noise array (can be NULL) */
   void *mask;        /* mask array (can be NULL)  */
+  void *seg;         /* seg array (can be NULL)  */
   int dtype;         /* element type of image     */
   int ndtype;        /* element type of noise     */
   int mdtype;        /* element type of mask      */
+  int sdtype;        /* element type of seg      */
   int w;             /* array width               */
   int h;             /* array height              */
   double noiseval;   /* scalar noise value; used only if noise == NULL */
@@ -256,6 +258,7 @@ int sep_sum_circle(sep_image *image,
 		   double x,          /* center of aperture in x */
 		   double y,          /* center of aperture in y */
 		   double r,          /* radius of aperture */
+		   int id,            /* optional id to test against seg array */
 		   int subpix,        /* subpixel sampling */
 		   short inflags,     /* input flags (see below) */
 		   double *sum,       /* OUTPUT: sum */
@@ -266,17 +269,17 @@ int sep_sum_circle(sep_image *image,
 
 int sep_sum_circann(sep_image *image,
                     double x, double y, double rin, double rout,
-                    int subpix, short inflags,
+                    int id, int subpix, short inflags,
 		    double *sum, double *sumerr, double *area, short *flag);
 
 int sep_sum_ellipse(sep_image *image,
 		    double x, double y, double a, double b, double theta,
-		    double r, int subpix, short inflags,
+		    double r, int id, int subpix, short inflags,
 		    double *sum, double *sumerr, double *area, short *flag);
 
 int sep_sum_ellipann(sep_image *image,
 		     double x, double y, double a, double b, double theta,
-		     double rin, double rout, int subpix, short inflags,
+		     double rin, double rout, int id, int subpix, short inflags,
 		     double *sum, double *sumerr, double *area, short *flag);
 
 /* sep_sum_circann_multi()
@@ -296,7 +299,7 @@ int sep_sum_ellipann(sep_image *image,
  * flag:     Output flag (non-array).
  */
 int sep_sum_circann_multi(sep_image *im,
-			  double x, double y, double rmax, int n, int subpix,
+			  double x, double y, double rmax, int n, int id, int subpix,
                           short inflag,
 			  double *sum, double *sumvar, double *area,
 			  double *maskarea, short *flag);
@@ -316,7 +319,7 @@ int sep_sum_circann_multi(sep_image *im,
  * flag : (output) scalar flag
  */
 int sep_flux_radius(sep_image *im,
-		    double x, double y, double rmax, int subpix, short inflag,
+		    double x, double y, double rmax, int id, int subpix, short inflag,
 		    double *fluxtot, double *fluxfrac, int n,
 		    double *r, short *flag);
 
@@ -337,7 +340,7 @@ int sep_flux_radius(sep_image *im,
  *                        kronrad = 0.
  */
 int sep_kron_radius(sep_image *im, double x, double y,
-		    double cxx, double cyy, double cxy, double r,
+		    double cxx, double cyy, double cxy, double r, int id, 
 		    double *kronrad, short *flag);
 
 

--- a/src/sep.h
+++ b/src/sep.h
@@ -63,11 +63,11 @@ typedef struct {
   void *data;        /* data array                */
   void *noise;       /* noise array (can be NULL) */
   void *mask;        /* mask array (can be NULL)  */
-  void *seg;         /* seg array (can be NULL)  */
+  void *segmap;      /* segmap array (can be NULL)  */
   int dtype;         /* element type of image     */
   int ndtype;        /* element type of noise     */
   int mdtype;        /* element type of mask      */
-  int sdtype;        /* element type of seg      */
+  int sdtype;        /* element type of segmap    */
   int w;             /* array width               */
   int h;             /* array height              */
   double noiseval;   /* scalar noise value; used only if noise == NULL */
@@ -258,7 +258,7 @@ int sep_sum_circle(sep_image *image,
 		   double x,          /* center of aperture in x */
 		   double y,          /* center of aperture in y */
 		   double r,          /* radius of aperture */
-		   int id,            /* optional id to test against seg array */
+		   int id,            /* optional id to test against segmap array */
 		   int subpix,        /* subpixel sampling */
 		   short inflags,     /* input flags (see below) */
 		   double *sum,       /* OUTPUT: sum */

--- a/test.py
+++ b/test.py
@@ -570,7 +570,72 @@ def test_aperture_bkgann_ones():
     f, _, _ = sep.sum_ellipse(data, x, y, 2., 1., np.pi/4., r, bkgann=bkgann)
     assert_allclose(f, 0., rtol=0., atol=1.e-13)
 
+def test_masked_segmentation_measurements():
+    """Test measurements with segmentation masking"""
+    
+    NX = 100
+    data = np.zeros((NX*2,NX*2))
+    yp, xp = np.indices(data.shape)
+    
+    ####
+    # Make two 2D gaussians that slightly overlap
+    
+    # width of the 2D objects
+    gsigma = 10.  
+      
+    # offset between two gaussians in sigmas
+    off = 4 
 
+    for xy in [[NX,NX], [NX+off*gsigma, NX+off*gsigma]]:
+        R = np.sqrt((xp-xy[0])**2+(yp-xy[1])**2)
+        g_i = np.exp(-R**2/2/gsigma**2)
+        data += g_i
+    
+    # Absolute total
+    total_exact = g_i.sum()
+    
+    # Add some noise
+    rms = 0.02
+    np.random.seed(1)
+    data += np.random.normal(size=data.shape)*rms
+    
+    # Run source detection
+    objs, seg = sep.extract(data, thresh=1.2, err=rms, mask=None, segmentation_map=True)
+    seg_id = np.arange(1, len(objs)+1, dtype=np.int32)
+    
+    # Compute Kron/Auto parameters
+    x, y, a, b = objs['x'], objs['y'], objs['a'], objs['b']
+    theta = objs['theta']
+    
+    kronrad, krflag = sep.kron_radius(data, x, y, a, b, theta, 6.0)
+    
+    flux_auto, fluxerr, flag = sep.sum_ellipse(data, x, y, a, b, theta,
+                                               2.5*kronrad, 
+                                               seg=seg, seg_id=seg_id, 
+                                               subpix=1)
+    
+    # Test total flux
+    assert_allclose(flux_auto, total_exact, rtol=5.e-2)
+        
+    # Flux_radius
+    for flux_fraction in [0.2, 0.5]:
+    
+        # Exact solution
+        rhalf_exact = np.sqrt(-np.log(1-flux_fraction)*gsigma**2*2)
+    
+        # Masked measurement
+        flux_radius, flag = sep.flux_radius(data, x, y, 6.*a, flux_fraction,
+                                        seg_id=seg_id, seg=seg, 
+                                        normflux=flux_auto, subpix=5)
+        
+        # Test flux fraction
+        assert_allclose(flux_radius, rhalf_exact, rtol=5.e-2)
+    
+    if False:
+        print('test_masked_flux_radius')
+        print(total_exact, flux_auto)
+        print(rhalf_exact, flux_radius)
+    
 def test_mask_ellipse():
     arr = np.zeros((20, 20), dtype=np.bool)
 

--- a/test.py
+++ b/test.py
@@ -600,7 +600,9 @@ def test_masked_segmentation_measurements():
     data += np.random.normal(size=data.shape)*rms
     
     # Run source detection
-    objs, seg = sep.extract(data, thresh=1.2, err=rms, mask=None, segmentation_map=True)
+    objs, segmap = sep.extract(data, thresh=1.2, err=rms, mask=None,
+                               segmentation_map=True)
+    
     seg_id = np.arange(1, len(objs)+1, dtype=np.int32)
     
     # Compute Kron/Auto parameters
@@ -611,7 +613,7 @@ def test_masked_segmentation_measurements():
     
     flux_auto, fluxerr, flag = sep.sum_ellipse(data, x, y, a, b, theta,
                                                2.5*kronrad, 
-                                               seg=seg, seg_id=seg_id, 
+                                               segmap=segmap, seg_id=seg_id, 
                                                subpix=1)
     
     # Test total flux
@@ -625,7 +627,7 @@ def test_masked_segmentation_measurements():
     
         # Masked measurement
         flux_radius, flag = sep.flux_radius(data, x, y, 6.*a, flux_fraction,
-                                        seg_id=seg_id, seg=seg, 
+                                        seg_id=seg_id, segmap=segmap, 
                                         normflux=flux_auto, subpix=5)
         
         # Test flux fraction


### PR DESCRIPTION
I've tried to implement some basic segmentation masking in the photometry and measurement functions (``flux_radius``, ``kron_radius``, but not yet ``winpos``) to address the point raised in  https://github.com/kbarbary/sep/issues/60.  It's not full ``MASK_TYPE = CORRECT`` behavior, but rather simply masks nonzero pixels in neighboring segments.