### PR TITLE
add debug symbols to build, fix for gcc 8.2 compiling errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ else:
     headerfiles = glob(os.path.join("src", "*.h"))
     include_dirs=[numpy.get_include(), "src"]
     extensions = [Extension("sep", sourcefiles, include_dirs=include_dirs,
-                            depends=headerfiles)]
+                            depends=headerfiles, extra_compile_args=['-g0'])]
     if USE_CYTHON:
         from Cython.Build import cythonize
         extensions = cythonize(extensions)


### PR DESCRIPTION
With gcc 8.2 and after, libelf is presenting problems with cython compiled code. Just look to cython/cython#2865

To fix this, it is needed to add debug symbols to extension as extra compiling args. I don't tested performance with this option.