### PR TITLE
bench.py photutils.Background AttributeError

### DIFF
--- a/bench.py
+++ b/bench.py
@@ -18,11 +18,11 @@ try:
     from fitsio import read as getdata
     HAVE_FITS = True
     NEED_BYTESWAP = False
-except:
+except ImportError:
     try:
         from astropy.io.fits import getdata
         HAVE_FITS = True
-    except:
+    except ImportError:
         HAVE_FITS = False
 
 CONDENSED = True

--- a/bench.py
+++ b/bench.py
@@ -35,7 +35,7 @@ if HAVE_FITS:
     print("test image dtype:", data.dtype)
 
     t0 = time.time()
-    bkg = sep.Background(data) # estimate background
+    bkg = sep.Background(data)  # estimate background
     t1 = time.time()
     print("measure background: {0:6.2f} ms".format((t1-t0) * 1.e3))
 
@@ -94,9 +94,9 @@ for ntile in [4]:
     if HAVE_PHOTUTILS:
         t0 = time.time()
         try:
-            bkg = photutils.Background(data, (64, 64)) # estimate background
+            bkg = photutils.Background(data, (64, 64))  # estimate background
         except AttributeError:
-            bkg = photutils.Background2D(data, (64, 64)) # estimate background
+            bkg = photutils.Background2D(data, (64, 64))  # estimate background
         t1 = time.time()
         t_pu = (t1-t0) * 1.e3
         line += "      {0:7.2f} ms | {1:6.2f} |".format(t_pu, t_pu/t_sep)

--- a/bench.py
+++ b/bench.py
@@ -30,7 +30,7 @@ CONDENSED = True
 if HAVE_FITS:
     rawdata = getdata(join("data", "image.fits"))  # original is 256 x 256
     data = np.tile(rawdata, (4, 4))
-    
+
     print("test image shape:", data.shape)
     print("test image dtype:", data.dtype)
 
@@ -93,7 +93,10 @@ for ntile in [4]:
 
     if HAVE_PHOTUTILS:
         t0 = time.time()
-        bkg = photutils.Background(data, (64, 64)) # estimate background
+        try:
+            bkg = photutils.Background(data, (64, 64)) # estimate background
+        except AttributeError:
+            bkg = photutils.Background2D(data, (64, 64)) # estimate background
         t1 = time.time()
         t_pu = (t1-t0) * 1.e3
         line += "      {0:7.2f} ms | {1:6.2f} |".format(t_pu, t_pu/t_sep)


### PR DESCRIPTION
Originally the ``bench.py`` contained a line
```python
bkg = photutils.Background(data, (64, 64)) # estimate background
```
but as far as I know, it should be ``photutils.Background2D`` at least since middle of 2016. I am not sure the versions prior to that used ``photutils.Background``, so I slightly modified:
```python
try:
    bkg = photutils.Background(data, (64, 64))  # estimate background
except AttributeError:
    bkg = photutils.Background2D(data, (64, 64))  # estimate background
```
Other updates are minor (``except`` to ``except ImportError`` etc).

Results on my Mac (MBP 15" 2018, 2.6 GHz i7) MacOS 10.14.6:
```
(sep_benchmark) ysBach-A1990: ~/Dropbox/github/fork/sep$ python -W ignore bench.py
test image shape: (1024, 1024)
test image dtype: float32
measure background:  11.23 ms
subtract background:   3.26 ms
background array:   6.74 ms
rms array:   4.87 ms
extract:  79.08 ms  [1167 objects]

sep version:       1.10.0
photutils version: 0.7.1

| test                    | sep             | photutils       | ratio  |
|-------------------------|-----------------|-----------------|--------|
| 1024^2 image background |         8.76 ms |       833.15 ms |  95.14 |
| circles  r= 5  subpix=5 |    3.33 us/aper |   40.47 us/aper |  12.16 |
| circles  r= 5  exact    |    3.22 us/aper |   40.59 us/aper |  12.62 |
| ellipses r= 5  subpix=5 |    3.57 us/aper |   43.64 us/aper |  12.21 |
| ellipses r= 5  exact    |    8.28 us/aper |   58.07 us/aper |   7.01 |
```