### PR TITLE
Support pep518

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include README.md
 include CHANGES.md
 include AUTHORS.md
 include licenses/*
+include pyproject.toml
 
 # do not include sep.pyx (see setup.py).
 include src/*.[c,h,i]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy", "Cython"]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy", "Cython"]
+requires = ["setuptools", "wheel", "oldest-supported-numpy", "Cython"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
By adding `pyproject.toml`, the project will be compatible with PEP518, declaring its built time requirements.

This means that you can create a wheel in an empty venv with the source code by runing

```pip wheel .```