### PR TITLE
Run benchmarks nloop times

### DIFF
--- a/bench.py
+++ b/bench.py
@@ -80,25 +80,28 @@ else:
 |-------------------------|-----------------|""")
     blankline = "|                         |                 |"
 
+nloop = 50
 
 for ntile in [4]:
     data = np.tile(rawdata, (ntile, ntile))
     line = "| {0:4d}^2 image background |".format(data.shape[0])
 
     t0 = time.time()
-    bkg = sep.Background(data)
+    for _ in xrange(0, nloop):
+        bkg = sep.Background(data)
     t1 = time.time()
-    t_sep = (t1-t0) * 1.e3
+    t_sep = (t1-t0) * 1.e3 / nloop
     line += "      {0:7.2f} ms |".format(t_sep)
 
     if HAVE_PHOTUTILS:
         t0 = time.time()
-        try:
-            bkg = photutils.Background(data, (64, 64))  # estimate background
-        except AttributeError:
-            bkg = photutils.Background2D(data, (64, 64))  # estimate background
+        for _ in xrange(0, nloop):
+            try:
+                bkg = photutils.Background(data, (64, 64))  # estimate background
+            except AttributeError:
+                bkg = photutils.Background2D(data, (64, 64))  # estimate background
         t1 = time.time()
-        t_pu = (t1-t0) * 1.e3
+        t_pu = (t1-t0) * 1.e3 / nloop
         line += "      {0:7.2f} ms | {1:6.2f} |".format(t_pu, t_pu/t_sep)
 
     print(line)
@@ -114,7 +117,6 @@ if not CONDENSED:
     print(line)
 
 naper = 1000
-nloop = 1
 data = np.ones((2000, 2000), dtype=np.float32)
 x = np.random.uniform(200., 1800., naper)
 y = np.random.uniform(200., 1800., naper)
@@ -133,7 +135,8 @@ for r in r_list:
         line = "| circles  r={0:2d}  {1:8s} |".format(int(r), label)
 
         t0 = time.time()
-        flux, fluxerr, flag = sep.sum_circle(data, x, y, r, subpix=subpix)
+        for _ in xrange(0, nloop):
+            flux, fluxerr, flag = sep.sum_circle(data, x, y, r, subpix=subpix)
         t1 = time.time()
         t_sep = (t1-t0) * 1.e6 / naper / nloop
         line += " {0:7.2f} us/aper |".format(t_sep)
@@ -141,10 +144,11 @@ for r in r_list:
         if HAVE_PHOTUTILS:
             apertures = photutils.CircularAperture((x, y), r)
             t0 = time.time()
-            res = photutils.aperture_photometry(
-                data, apertures, method=method, subpixels=subpix)
+            for _ in xrange(0, nloop):
+                res = photutils.aperture_photometry(
+                    data, apertures, method=method, subpixels=subpix)
             t1 = time.time()
-            t_pu = (t1-t0) * 1.e6 / naper
+            t_pu = (t1-t0) * 1.e6 / naper / nloop
             line += " {0:7.2f} us/aper | {1:6.2f} |".format(t_pu, t_pu/t_sep)
 
         print(line)
@@ -152,8 +156,6 @@ for r in r_list:
 if not CONDENSED:
     print(blankline)
 
-naper = 1000
-nloop = 1
 a = 1.
 b = 1.
 theta = np.pi/4.
@@ -163,8 +165,9 @@ for r in r_list:
         line = "| ellipses r={0:2d}  {1:8s} |".format(int(r), label)
 
         t0 = time.time()
-        flux, fluxerr, flag = sep.sum_ellipse(data, x, y, a, b, theta, r,
-                                              subpix=subpix)
+        for _ in xrange(0, nloop):
+            flux, fluxerr, flag = sep.sum_ellipse(data, x, y, a, b, theta, r,
+                                                subpix=subpix)
         t1 = time.time()
         t_sep = (t1-t0) * 1.e6 / naper / nloop
         line += " {0:7.2f} us/aper |".format(t_sep)
@@ -172,10 +175,11 @@ for r in r_list:
         if HAVE_PHOTUTILS:
             apertures = photutils.EllipticalAperture((x, y), a*r, b*r, theta)
             t0 = time.time()
-            res = photutils.aperture_photometry(
-                data, apertures, method=method, subpixels=subpix)
+            for _ in xrange(0, nloop):
+                res = photutils.aperture_photometry(
+                    data, apertures, method=method, subpixels=subpix)
             t1 = time.time()
-            t_pu = (t1-t0) * 1.e6 / naper
+            t_pu = (t1-t0) * 1.e6 / naper / nloop
             line += " {0:7.2f} us/aper | {1:6.2f} |".format(t_pu, t_pu/t_sep)
 
         print(line)


### PR DESCRIPTION
Looks like at least some benches already used nloop variable in time calculations, but never looped. Each benchmark executing just once resulted in fairly unreliable numbers across runs.

This change makes each bench run 50 times, and averages the timing across them, making numbers more reproducible.