### PR TITLE
Consistently export only public API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ link_directories(${CMAKE_LIBRARY_PATH} ${CMAKE_SOURCE_DIR}/src)
 add_library(sep SHARED ${SOURCES})
 set_target_properties(sep PROPERTIES OUTPUT_NAME sep)
 set_target_properties(sep PROPERTIES VERSION 0.6.0 SOVERSION 0)
+set_target_properties(sep PROPERTIES C_VISIBILITY_PRESET hidden)
 
 if (NOT MSVC)
    target_link_libraries(sep m)

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ CPPFLAGS ?=
 LDFLAGS ?=
 
 CPPFLAGS += -Isrc
-CFLAGS += -Wall -Wextra -O3  # -Werror
+CFLAGS += -Wall -Wextra -O3 -fvisibility=hidden  # -Werror
 CFLAGS_LIB = $(CFLAGS) -fPIC
 LDFLAGS_LIB = $(LDFLAGS) -shared -Wl,$(SONAME_FLAG),$(SONAME_MAJOR)
 

--- a/src/sep.h
+++ b/src/sep.h
@@ -20,6 +20,12 @@
 *
 *%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*/
 
+#ifdef _MSC_VER
+#define SEP_API __declspec(dllexport)
+#else
+#define SEP_API __attribute__((visibility("default")))
+#endif
+
 /* datatype codes */
 #define SEP_TBYTE        11  /* 8-bit unsigned byte */
 #define SEP_TINT         31  /* native int type */
@@ -90,7 +96,7 @@ typedef struct {
   float globalrms;   /* global sigma */
   float *back;       /* node data for interpolation */
   float *dback;
-  float *sigma;    
+  float *sigma;
   float *dsigma;
 } sep_bkg;
 
@@ -104,7 +110,7 @@ typedef struct {
   float	 *thresh;              /* threshold (ADU)                          */
   int	 *npix;                 /* # pixels extracted (size of pix array)   */
   int    *tnpix;                /* # pixels above thresh (unconvolved)      */
-  int	 *xmin, *xmax;      
+  int	 *xmin, *xmax;
   int    *ymin, *ymax;
   double *x, *y;                 /* barycenter (first moments)               */
   double *x2, *y2, *xy;		 /* second moments                           */
@@ -128,22 +134,22 @@ typedef struct {
 /*--------------------- global background estimation ------------------------*/
 
 /* sep_background()
- * 
+ *
  * Create representation of spatially varying image background and variance.
  *
- * Note that the returned pointer must eventually be freed by calling 
+ * Note that the returned pointer must eventually be freed by calling
  * `sep_bkg_free()`.
  *
  * In addition to the image mask (if present), pixels <= -1e30 and NaN
  * are ignored.
- * 
+ *
  * Source Extractor defaults:
- * 
+ *
  * - bw, bh = (64, 64)
  * - fw, fh = (3, 3)
  * - fthresh = 0.0
  */
-int sep_background(sep_image *image,
+SEP_API int sep_background(sep_image *image,
                    int bw, int bh,   /* size of a single background tile */
                    int fw, int fh,   /* filter size in tiles             */
                    double fthresh,   /* filter threshold                 */
@@ -154,8 +160,8 @@ int sep_background(sep_image *image,
  *
  * Get the estimate of the global background "median" or standard deviation.
  */
-float sep_bkg_global(sep_bkg *bkg);
-float sep_bkg_globalrms(sep_bkg *bkg);
+SEP_API float sep_bkg_global(sep_bkg *bkg);
+SEP_API float sep_bkg_globalrms(sep_bkg *bkg);
 
 
 /* sep_bkg_pix()
@@ -163,37 +169,37 @@ float sep_bkg_globalrms(sep_bkg *bkg);
  * Return background at (x, y).
  * Unlike other routines, this uses simple linear interpolation.
  */
-float sep_bkg_pix(sep_bkg *bkg, int x, int y);
+SEP_API float sep_bkg_pix(sep_bkg *bkg, int x, int y);
 
 
 /* sep_bkg_[sub,rms]line()
- * 
+ *
  * Evaluate the background or RMS at line `y`.
  * Uses bicubic spline interpolation between background map verticies.
  * The second function subtracts the background from the input array.
  * Line must be an array with same width as original image.
  */
-int sep_bkg_line(sep_bkg *bkg, int y, void *line, int dtype);
-int sep_bkg_subline(sep_bkg *bkg, int y, void *line, int dtype);
-int sep_bkg_rmsline(sep_bkg *bkg, int y, void *line, int dtype);
+SEP_API int sep_bkg_line(sep_bkg *bkg, int y, void *line, int dtype);
+SEP_API int sep_bkg_subline(sep_bkg *bkg, int y, void *line, int dtype);
+SEP_API int sep_bkg_rmsline(sep_bkg *bkg, int y, void *line, int dtype);
 
 
 /* sep_bkg_[sub,rms]array()
- * 
+ *
  * Evaluate the background or RMS for entire image.
  * Uses bicubic spline interpolation between background map verticies.
  * The second function subtracts the background from the input array.
  * `arr` must be an array of the same size as original image.
  */
-int sep_bkg_array(sep_bkg *bkg, void *arr, int dtype);
-int sep_bkg_subarray(sep_bkg *bkg, void *arr, int dtype);
-int sep_bkg_rmsarray(sep_bkg *bkg, void *arr, int dtype);
+SEP_API int sep_bkg_array(sep_bkg *bkg, void *arr, int dtype);
+SEP_API int sep_bkg_subarray(sep_bkg *bkg, void *arr, int dtype);
+SEP_API int sep_bkg_rmsarray(sep_bkg *bkg, void *arr, int dtype);
 
 /* sep_bkg_free()
  *
  * Free memory associated with bkg.
  */
-void sep_bkg_free(sep_bkg *bkg);
+SEP_API void sep_bkg_free(sep_bkg *bkg);
 
 /*-------------------------- source extraction ------------------------------*/
 
@@ -204,15 +210,15 @@ void sep_bkg_free(sep_bkg *bkg);
  *
  * Notes
  * -----
- * `dtype` and `ndtype` indicate the data type (float, int, double) of the 
+ * `dtype` and `ndtype` indicate the data type (float, int, double) of the
  * image and noise arrays, respectively.
  *
  * If `noise` is NULL, thresh is interpreted as an absolute threshold.
  * If `noise` is not null, thresh is interpreted as a relative threshold
  * (the absolute threshold will be thresh*noise[i,j]).
- * 
+ *
  */
-int sep_extract(sep_image *image,
+SEP_API int sep_extract(sep_image *image,
 		float thresh,         /* detection threshold           [1.5] */
                 int thresh_type,      /* threshold units    [SEP_THRESH_REL] */
 		int minarea,          /* minimum area in pixels          [5] */
@@ -229,21 +235,21 @@ int sep_extract(sep_image *image,
 
 
 /* set and get the size of the pixel stack used in extract() */
-void sep_set_extract_pixstack(size_t val);
-size_t sep_get_extract_pixstack(void);
+SEP_API void sep_set_extract_pixstack(size_t val);
+SEP_API size_t sep_get_extract_pixstack(void);
 
 /* set and get the number of sub-objects limit when deblending in extract() */
-void sep_set_sub_object_limit(int val);
-int sep_get_sub_object_limit(void);
+SEP_API void sep_set_sub_object_limit(int val);
+SEP_API int sep_get_sub_object_limit(void);
 
 /* free memory associated with a catalog */
-void sep_catalog_free(sep_catalog *catalog);
+SEP_API void sep_catalog_free(sep_catalog *catalog);
 
 /*-------------------------- aperture photometry ----------------------------*/
 
 
 /* Sum array values within a circular aperture.
- * 
+ *
  * Notes
  * -----
  * error : Can be a scalar (default), an array, or NULL
@@ -258,7 +264,7 @@ void sep_catalog_free(sep_catalog *catalog);
  *        corrected. The area can differ from the exact area of a circle due
  *        to inexact subpixel sampling and intersection with array boundaries.
  */
-int sep_sum_circle(sep_image *image,
+SEP_API int sep_sum_circle(sep_image *image,
 		   double x,          /* center of aperture in x */
 		   double y,          /* center of aperture in y */
 		   double r,          /* radius of aperture */
@@ -271,17 +277,17 @@ int sep_sum_circle(sep_image *image,
 		   short *flag);      /* OUTPUT: flags */
 
 
-int sep_sum_circann(sep_image *image,
+SEP_API int sep_sum_circann(sep_image *image,
                     double x, double y, double rin, double rout,
                     int id, int subpix, short inflags,
 		    double *sum, double *sumerr, double *area, short *flag);
 
-int sep_sum_ellipse(sep_image *image,
+SEP_API int sep_sum_ellipse(sep_image *image,
 		    double x, double y, double a, double b, double theta,
 		    double r, int id, int subpix, short inflags,
 		    double *sum, double *sumerr, double *area, short *flag);
 
-int sep_sum_ellipann(sep_image *image,
+SEP_API int sep_sum_ellipann(sep_image *image,
 		     double x, double y, double a, double b, double theta,
 		     double rin, double rout, int id, int subpix, short inflags,
 		     double *sum, double *sumerr, double *area, short *flag);
@@ -291,7 +297,7 @@ int sep_sum_ellipann(sep_image *image,
  * Sum an array of circular annuli more efficiently (but with no exact mode).
  *
  * Notable parameters:
- * 
+ *
  * rmax:     Input radii are  [rmax/n, 2*rmax/n, 3*rmax/n, ..., rmax].
  * n:        Length of input and output arrays.
  * sum:      Preallocated array of length n holding sums in annuli. sum[0]
@@ -302,7 +308,7 @@ int sep_sum_ellipann(sep_image *image,
              annulus (if mask not NULL).
  * flag:     Output flag (non-array).
  */
-int sep_sum_circann_multi(sep_image *im,
+SEP_API int sep_sum_circann_multi(sep_image *im,
 			  double x, double y, double rmax, int n, int id, int subpix,
                           short inflag,
 			  double *sum, double *sumvar, double *area,
@@ -322,14 +328,14 @@ int sep_sum_circann_multi(sep_image *im,
  * r : (output) result array of length n.
  * flag : (output) scalar flag
  */
-int sep_flux_radius(sep_image *im,
+SEP_API int sep_flux_radius(sep_image *im,
 		    double x, double y, double rmax, int id, int subpix, short inflag,
 		    double *fluxtot, double *fluxfrac, int n,
 		    double *r, short *flag);
 
 /* sep_kron_radius()
  *
- * Calculate Kron radius within an ellipse given by 
+ * Calculate Kron radius within an ellipse given by
  *
  *     cxx*(x'-x)^2 + cyy*(y'-y)^2 + cxy*(x'-x)*(y'-y) < r^2
  *
@@ -343,8 +349,8 @@ int sep_flux_radius(sep_image *im,
  * SEP_APER_NONPOSITIVE - There was a nonpositive numerator or deminator.
  *                        kronrad = 0.
  */
-int sep_kron_radius(sep_image *im, double x, double y,
-		    double cxx, double cyy, double cxy, double r, int id, 
+SEP_API int sep_kron_radius(sep_image *im, double x, double y,
+		    double cxx, double cyy, double cxy, double r, int id,
 		    double *kronrad, short *flag);
 
 
@@ -360,7 +366,7 @@ int sep_kron_radius(sep_image *im, double x, double y,
  * xout, yout : output center.
  * niter      : number of iterations used.
  */
-int sep_windowed(sep_image *im,
+SEP_API int sep_windowed(sep_image *im,
                  double x, double y, double sig, int subpix, short inflag,
                  double *xout, double *yout, int *niter, short *flag);
 
@@ -369,9 +375,9 @@ int sep_windowed(sep_image *im,
  *
  * Set array elements within an ellipitcal aperture to a given value.
  *
- * Ellipse: cxx*(x'-x)^2 + cyy*(y'-y)^2 + cxy*(x'-x)*(y'-y) = r^2  
+ * Ellipse: cxx*(x'-x)^2 + cyy*(y'-y)^2 + cxy*(x'-x)*(y'-y) = r^2
  */
-void sep_set_ellipse(unsigned char *arr, int w, int h,
+SEP_API void sep_set_ellipse(unsigned char *arr, int w, int h,
 		     double x, double y, double cxx, double cyy, double cxy,
 		     double r, unsigned char val);
 
@@ -388,15 +394,15 @@ void sep_set_ellipse(unsigned char *arr, int w, int h,
  * b = semiminor axis
  * theta = angle in radians counter-clockwise from positive x axis
  */
-int sep_ellipse_axes(double cxx, double cyy, double cxy,
+SEP_API int sep_ellipse_axes(double cxx, double cyy, double cxy,
 		     double *a, double *b, double *theta);
-void sep_ellipse_coeffs(double a, double b, double theta,
+SEP_API void sep_ellipse_coeffs(double a, double b, double theta,
 			double *cxx, double *cyy, double *cxy);
 
 /*----------------------- info & error messaging ----------------------------*/
 
 /* sep_version_string : library version (e.g., "0.2.0") */
-extern char *sep_version_string;
+SEP_API extern char *sep_version_string;
 
 /* sep_get_errmsg()
  *
@@ -404,7 +410,7 @@ extern char *sep_version_string;
  * error status value.  The message may be up to 60 characters long, plus
  * the terminating null character.
  */
-void sep_get_errmsg(int status, char *errtext);
+SEP_API void sep_get_errmsg(int status, char *errtext);
 
 
 /* sep_get_errdetail()
@@ -412,4 +418,4 @@ void sep_get_errmsg(int status, char *errtext);
  * Return a longer error message with more specifics about the problem.
  * The message may be up to 512 characters.
  */
-void sep_get_errdetail(char *errtext);
+SEP_API void sep_get_errdetail(char *errtext);


### PR DESCRIPTION
Previously, there were two problems with linkage:

1. On Unix builds, _all_ of the symbols were exported, including all the private helpers and variables, polluting the global namespace and making it too easy to overlap with similar names in other libraries / object files within the same app.
2. On Windows builds, _none_ of the symbols were exported in the DLL, making it impossible to use SEP.

This PR changes both of those things by switching to default hidden visibility and explicitly exporting only symbols in `sep.h` (that is, public API).

---

**Before (Unix)**

```
$ nm -D --defined-only lxbuild/libsep.so.0.6.0
000000000021c278 B __bss_start
000000000021c278 D _edata
000000000021c680 B _end
000000000001838c T _fini
00000000000023f8 T _init
0000000000005650 T addobjdeep
0000000000003f10 T allocdeblend
0000000000002d30 T analyse
0000000000002990 T analysemthresh
00000000000055c0 T apply_mask_line
00000000000055a0 T arraybuffer_free
0000000000005440 T arraybuffer_init
00000000000053c0 T arraybuffer_readline
0000000000013dc0 T backguess
0000000000013bb0 T backhisto
0000000000013590 T backstat
0000000000004990 T belong
00000000000153b0 T bkg_line_flt_internal
000000000000c720 T circle_segment
0000000000005af0 T clean
0000000000017490 T convert_array_byt
00000000000171f0 T convert_array_dbl
0000000000017060 T convert_array_flt
0000000000017310 T convert_array_int
0000000000017050 T convert_byt
0000000000017020 T convert_dbl
0000000000017030 T convert_flt
0000000000017040 T convert_int
00000000000060c0 T convert_to_catalog
00000000000037a0 T convolve
0000000000004a10 T createsubmap
0000000000004ae0 T deblend
000000000021c268 D extract_pixstack
00000000000142b0 T filterback
0000000000018320 T fqmedian
0000000000005f30 T free_catalog_fields
0000000000003ec0 T freedeblend
0000000000004060 T gatherup
0000000000017f40 T get_array_converter
0000000000018250 T get_array_subtractor
0000000000017fd0 T get_array_writer
0000000000017eb0 T get_converter
0000000000008d10 T lutz
0000000000008a00 T lutzalloc
0000000000008950 T lutzfree
0000000000008c50 T lutzsort
0000000000014f40 T makebackspline
0000000000003b50 T matched_filter
000000000021c260 D nsonmax
000000000021c678 B plistexist_cdvalue
000000000021c664 B plistexist_thresh
000000000021c670 B plistexist_var
0000000000005a40 T plistinit
000000000021c660 B plistoff_cdvalue
000000000021c668 B plistoff_thresh
000000000021c66c B plistoff_value
000000000021c674 B plistoff_var
000000000021c67c B plistsize
0000000000002bc0 T preanalyse
0000000000018230 T put_errdetail
00000000000167c0 T sep_background
0000000000016280 T sep_bkg_array
0000000000016780 T sep_bkg_free
00000000000151d0 T sep_bkg_global
00000000000151e0 T sep_bkg_globalrms
0000000000016060 T sep_bkg_line
0000000000016020 T sep_bkg_line_flt
00000000000151f0 T sep_bkg_pix
00000000000163f0 T sep_bkg_rmsarray
0000000000016170 T sep_bkg_rmsline
0000000000016040 T sep_bkg_rmsline_flt
0000000000016660 T sep_bkg_subarray
0000000000016560 T sep_bkg_subline
0000000000006df0 T sep_catalog_free
000000000000df60 T sep_ellipse_axes
000000000000e260 T sep_ellipse_coeffs
0000000000006e10 T sep_extract
0000000000012070 T sep_flux_radius
0000000000018200 T sep_get_errdetail
0000000000018020 T sep_get_errmsg
00000000000053b0 T sep_get_extract_pixstack
0000000000003eb0 T sep_get_sub_object_limit
0000000000012240 T sep_kron_radius
0000000000012900 T sep_set_ellipse
00000000000053a0 T sep_set_extract_pixstack
0000000000003ea0 T sep_set_sub_object_limit
000000000000f8e0 T sep_sum_circann
0000000000011200 T sep_sum_circann_multi
000000000000e330 T sep_sum_circle
00000000000103b0 T sep_sum_ellipann
000000000000ec70 T sep_sum_ellipse
000000000021c270 D sep_version_string
0000000000012c30 T sep_windowed
00000000000058a0 T sortit
0000000000017940 T subtract_array_dbl
0000000000017ab0 T subtract_array_flt
0000000000017c90 T subtract_array_int
0000000000008cd0 T update
0000000000017630 T write_array_dbl
0000000000017750 T write_array_int
```

**After (Unix)**

```
$ nm -D --defined-only lxbuild-pub/libsep.so.0.6.0
000000000021e130 B __bss_start
000000000021e130 D _edata
000000000021e540 B _end
0000000000019bcc T _fini
0000000000001190 T _init
0000000000017ff0 T sep_background
00000000000155b0 T sep_bkg_array
0000000000017fb0 T sep_bkg_free
00000000000144c0 T sep_bkg_global
00000000000144d0 T sep_bkg_globalrms
0000000000015350 T sep_bkg_line
00000000000144e0 T sep_bkg_pix
0000000000016380 T sep_bkg_rmsarray
0000000000015480 T sep_bkg_rmsline
0000000000017250 T sep_bkg_subarray
0000000000017150 T sep_bkg_subline
0000000000005c90 T sep_catalog_free
000000000000d250 T sep_ellipse_axes
000000000000d550 T sep_ellipse_coeffs
0000000000005cb0 T sep_extract
0000000000011360 T sep_flux_radius
0000000000019b10 T sep_get_errdetail
0000000000019930 T sep_get_errmsg
0000000000003fe0 T sep_get_extract_pixstack
00000000000029c0 T sep_get_sub_object_limit
0000000000011530 T sep_kron_radius
0000000000011bf0 T sep_set_ellipse
0000000000003fd0 T sep_set_extract_pixstack
00000000000029b0 T sep_set_sub_object_limit
000000000000ebd0 T sep_sum_circann
00000000000104f0 T sep_sum_circann_multi
000000000000d620 T sep_sum_circle
000000000000f6a0 T sep_sum_ellipann
000000000000df60 T sep_sum_ellipse
000000000021e128 D sep_version_string
0000000000011f20 T sep_windowed
```

**Before (Windows)**

```
> dumpbin /exports .\vsbuild\Release\sep.dll
Microsoft (R) COFF/PE Dumper Version 14.16.27043.0
Copyright (C) Microsoft Corporation.  All rights reserved.


Dump of file .\vsbuild\Release\sep.dll

File Type: DLL

  Summary

        1000 .data
        1000 .rdata
        1000 .reloc
        1000 .rsrc
        1000 .text
```

**After (Windows)**

```
> dumpbin /exports .\vsbuild-pub\Release\sep.dll
Microsoft (R) COFF/PE Dumper Version 14.16.27043.0
Copyright (C) Microsoft Corporation.  All rights reserved.


Dump of file .\vsbuild-pub\Release\sep.dll

File Type: DLL

  Section contains the following exports for sep.dll

    00000000 characteristics
    FFFFFFFF time date stamp
        0.00 version
           1 ordinal base
          31 number of functions
          31 number of names

    ordinal hint RVA      name

          1    0 0000D960 sep_background
          2    1 0000E080 sep_bkg_array
          3    2 0000E1E0 sep_bkg_free
          4    3 0000E220 sep_bkg_global
          5    4 0000E230 sep_bkg_globalrms
          6    5 0000E240 sep_bkg_line
          7    6 0000E340 sep_bkg_pix
          8    7 0000E490 sep_bkg_rmsarray
          9    8 0000E5F0 sep_bkg_rmsline
         10    9 0000E6F0 sep_bkg_subarray
         11    A 0000E800 sep_bkg_subline
         12    B 00004360 sep_catalog_free
         13    C 00007430 sep_ellipse_axes
         14    D 00007580 sep_ellipse_coeffs
         15    E 00004390 sep_extract
         16    F 00007630 sep_flux_radius
         17   10 0000F020 sep_get_errdetail
         18   11 0000F060 sep_get_errmsg
         19   12 000056F0 sep_get_extract_pixstack
         20   13 00003220 sep_get_sub_object_limit
         21   14 000078B0 sep_kron_radius
         22   15 00007D00 sep_set_ellipse
         23   16 00005700 sep_set_extract_pixstack
         24   17 00003230 sep_set_sub_object_limit
         25   18 00007E20 sep_sum_circann
         26   19 00008620 sep_sum_circann_multi
         27   1A 00008EF0 sep_sum_circle
         28   1B 00009640 sep_sum_ellipann
         29   1C 0000A020 sep_sum_ellipse
         30   1D 00015008 sep_version_string
         31   1E 0000A8B0 sep_windowed

  Summary

        1000 .data
        4000 .rdata
        1000 .reloc
        1000 .rsrc
       10000 .text
```