### PR TITLE
Make the library threadsafe

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -7,3 +7,4 @@
 * Evert Rol (@evertrol): setup.py fixes
 * Joe Lyman (@lyalpha): Make deblending limit settable
 * Michael Wuertenberger (@mworion): PyPI wheels
+* Ingvar Stepanyan (@rreverser): Build system, public API and thread safety fixes.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,22 @@ unreleased
 
 * Changed `numpy.float` and `numpy.int` types for deprecations in numpy 1.20 (#96).
 
+* Make it possible to safely invoke C library from multiple threads on
+  independent inputs.
+
+  Global config functions such as `set_sub_object_limit()`
+  and `set_extract_pixstack()` still configure global params
+  (once for all threads), while other functions will retain their data
+  in thread-local storages, so they can be invoked from multiple threads as
+  long as they work on independent structures.
+
+  Library compilation will now require a C11 compatible compiler, which should
+  be nowadays available on all supported platforms.
+
+* Mark some pointer parameters with `const *`. This is a backward-compatible
+  change, but makes it easier to extract constants that can be safely shared
+  between multiple threads and/or invocations.
+
 v1.1.1 (6 January 2021)
 =======================
 

--- a/ctest/test_image.c
+++ b/ctest/test_image.c
@@ -32,58 +32,12 @@ float *uniformf(float a, float b, int n)
 {
   int i;
   float *result;
-    
+
   result = (float*)malloc(n*sizeof(float));
   for (i=0; i<n; i++)
     result[i] = a + (b-a) * rand() / ((double)RAND_MAX);
 
   return result;
-}
-
-double gaussrand()
-{
-  static double V1, V2, S;
-  static int phase = 0;
-  double x, u1, u2;
-  
-  if (phase == 0)
-    {
-      do
-	{
-	  u1 = (double)rand() / RAND_MAX;
-	  u2 = (double)rand() / RAND_MAX;
-	  
-	  V1 = 2.*u1 - 1.;
-	  V2 = 2.*u2 - 1.;
-	  S = V1*V1 + V2*V2;
-	} 
-      while (S >= 1. || S == 0.);
-      
-      x = V1 * sqrt(-2. * log(S) / S);
-    }
-  else
-    {
-      x = V2 * sqrt(-2. * log(S) / S);
-    }
-
-  phase = 1 - phase;
-  
-  return x;
-}
-
-float *makenoiseim(int nx, int ny, float mean, float sigma)
-{
-  int i, npix;
-  float *im, *imt;
-
-  im = (float*)malloc((npix=nx*ny)*sizeof(float));
-
-  /* fill with noise */
-  imt = im;
-  for (i=0; i<npix; i++, imt++)
-    *imt = mean + sigma*(float)gaussrand();
-
-  return im;
 }
 
 float *ones(int nx, int ny)
@@ -286,7 +240,7 @@ int main(int argc, char **argv)
   t1 = gettime_ns();
   if (status) goto exit;
   print_time("sep_bkg_array()", t1-t0);
-  
+
     /* subtract background */
   t0 = gettime_ns();
   status = sep_bkg_subarray(bkg, im.data, im.dtype);
@@ -294,7 +248,7 @@ int main(int argc, char **argv)
   if (status) goto exit;
   print_time("sep_bkg_subarray()", t1-t0);
 
-  /* extract sources 
+  /* extract sources
    * Note that we set deblend_cont = 1.0 to turn off deblending.
    */
   t0 = gettime_ns();

--- a/src/analyse.c
+++ b/src/analyse.c
@@ -109,7 +109,7 @@ void  preanalyse(int no, objliststruct *objlist)
   double	rv;
   int		x, y, xmin,xmax, ymin,ymax, fdnpix;
   int           xpeak, ypeak, xcpeak, ycpeak;
-  
+
   /*-----  initialize stacks and bounds */
   fdnpix = 0;
   rv = 0.0;
@@ -147,8 +147,8 @@ void  preanalyse(int no, objliststruct *objlist)
       if (ymax < y)
 	ymax = y;
       fdnpix++;
-    }    
-  
+    }
+
   obj->fdnpix = (LONG)fdnpix;
   obj->fdflux = (float)rv;
   obj->fdpeak = cpeak;
@@ -161,8 +161,6 @@ void  preanalyse(int no, objliststruct *objlist)
   obj->xmax = xmax;
   obj->ymin = ymin;
   obj->ymax = ymax;
-
-  return;
 }
 
 /******************************** analyse *********************************/
@@ -183,7 +181,7 @@ void  analyse(int no, objliststruct *objlist, int robust, double gain)
   int		x, y, xmin, ymin, area2, dnpix;
 
   preanalyse(no, objlist);
-  
+
   dnpix = 0;
   mx = my = tv = 0.0;
   mx2 = my2 = mxy = 0.0;
@@ -194,7 +192,7 @@ void  analyse(int no, objliststruct *objlist, int robust, double gain)
   rv2 = rv * rv;
   thresh2 = (thresh + peak)/2.0;
   area2 = 0;
-  
+
   xmin = obj->xmin;
   ymin = obj->ymin;
 
@@ -225,7 +223,7 @@ void  analyse(int no, objliststruct *objlist, int robust, double gain)
   if ((robust) && (obj->flag & SEP_OBJ_MERGED))
     {
       double xn, yn;
-	  
+
       xn = obj->mx-xmin;
       yn = obj->my-ymin;
       xm2 = mx2 / rv + xn*xn - 2*xm*xn;
@@ -290,7 +288,7 @@ void  analyse(int no, objliststruct *objlist, int robust, double gain)
   pmy2 = pmx2 = 0.5*(xm2+ym2);
   pmx2+=temp;
   pmy2-=temp;
-  
+
   obj->dnpix = (LONG)dnpix;
   obj->dflux = tv;
   obj->mx = xm+xmin;	/* add back xmin */
@@ -304,11 +302,11 @@ void  analyse(int no, objliststruct *objlist, int robust, double gain)
   obj->a = (float)sqrt(pmx2);
   obj->b = (float)sqrt(pmy2);
   obj->theta = theta;
-  
+
   obj->cxx = (float)(ym2/temp2);
   obj->cyy = (float)(xm2/temp2);
   obj->cxy = (float)(-2*xym/temp2);
-  
+
   darea = (double)area2 - dnpix;
   t1t2 = thresh/thresh2;
 
@@ -325,7 +323,4 @@ void  analyse(int no, objliststruct *objlist, int robust, double gain)
     {
       obj->abcor = 1.0;
     }
-
-  return;
-
 }

--- a/src/aperture.c
+++ b/src/aperture.c
@@ -36,7 +36,7 @@
 #define WINPOS_FAC      2.0     /* Centroid offset factor (2 for a Gaussian) */
 
 /*
-  Adding (void *) pointers is a GNU C extension, not part of standard C. 
+  Adding (void *) pointers is a GNU C extension, not part of standard C.
   When compiling on Windows with MS VIsual C compiler need to cast the
   (void *) to something the size of one byte.
 */
@@ -325,9 +325,9 @@ static void oversamp_ann_ellipse(double r, double b, double *r_in2,
  * This is just different enough from the other aperture functions
  * that it doesn't quite make sense to use aperture.i.
  */
-int sep_sum_circann_multi(sep_image *im,
-                          double x, double y, double rmax, int n, 
-                          int id, 
+int sep_sum_circann_multi(const sep_image *im,
+                          double x, double y, double rmax, int n,
+                          int id,
                           int subpix,
                           short inflag,
                           double *sum, double *sumvar, double *area,
@@ -436,7 +436,7 @@ int sep_sum_circann_multi(sep_image *im,
                   if (errisstd)
                     varpix *= varpix;
                 }
-              
+
               ismasked = 0;
               if (im->mask)
                 {
@@ -447,18 +447,18 @@ int sep_sum_circann_multi(sep_image *im,
                     }
                 }
 
-              /* Segmentation image:  
+              /* Segmentation image:
 
-    	           If `id` is negative, require segmented pixels within the 
+    	           If `id` is negative, require segmented pixels within the
     	           aperture.
 
     	           If `id` is positive, mask pixels with nonzero segment ids
     	           not equal to `id`.
 
-    	      */ 
+    	      */
     	      if (im->segmap)
       	        {
-      	          if (id > 0) 
+      	          if (id > 0)
       	            {
       	              if ((sconvert(segt) > 0.) & (sconvert(segt) != id))
       	                {
@@ -470,10 +470,10 @@ int sep_sum_circann_multi(sep_image *im,
     	                {
                           *flag |= SEP_APER_HASMASKED;
     	                  ismasked = 1;
-    	                }  	            
+    	                }
       	            }
       	        }
-      	        
+
               /* check if oversampling is needed (close to bin boundary?) */
               rpix = sqrt(rpix2);
               d = fmod(rpix, step);
@@ -583,8 +583,8 @@ static double inverse(double xmax, const double *y, int n, double ytarg)
   return step * (i + (ytarg - y[i-1])/(y[i] - y[i-1]));
 }
 
-int sep_flux_radius(sep_image *im,
-                    double x, double y, double rmax, int id, 
+int sep_flux_radius(const sep_image *im,
+                    double x, double y, double rmax, int id,
                     int subpix, short inflag,
                     const double *fluxtot, const double *fluxfrac, int n, double *r,
                     short *flag)
@@ -619,8 +619,8 @@ int sep_flux_radius(sep_image *im,
 
 /*****************************************************************************/
 /* calculate Kron radius from pixels within an ellipse. */
-int sep_kron_radius(sep_image *im, double x, double y,
-                    double cxx, double cyy, double cxy, double r, int id, 
+int sep_kron_radius(const sep_image *im, double x, double y,
+                    double cxx, double cyy, double cxy, double r, int id,
                     double *kronrad, short *flag)
 {
   float pix;
@@ -628,7 +628,7 @@ int sep_kron_radius(sep_image *im, double x, double y,
   int ix, iy, xmin, xmax, ymin, ymax, status, size, msize, ssize;
   long pos;
   int ismasked;
-  
+
   BYTE *datat, *maskt, *segt;
   converter convert, mconvert, sconvert;
 
@@ -675,18 +675,18 @@ int sep_kron_radius(sep_image *im, double x, double y,
               if ((pix < -BIG) || (im->mask && mconvert(maskt) > im->maskthresh))
                 ismasked = 1;
 
-              /* Segmentation image:  
+              /* Segmentation image:
 
-    	           If `id` is negative, require segmented pixels within the 
+    	           If `id` is negative, require segmented pixels within the
     	           aperture.
 
     	           If `id` is positive, mask pixels with nonzero segment ids
     	           not equal to `id`.
 
-    	      */ 
+    	      */
     	      if (im->segmap)
       	        {
-      	          if (id > 0) 
+      	          if (id > 0)
       	            {
       	              if ((sconvert(segt) > 0.) & (sconvert(segt) != id))
       	                {
@@ -696,10 +696,10 @@ int sep_kron_radius(sep_image *im, double x, double y,
     	              if (sconvert(segt) != -1*id)
     	                {
     	                  ismasked = 1;
-    	                }  	            
+    	                }
       	            }
       	        }
-                
+
               if (ismasked > 0)
                 {
                   *flag |= SEP_APER_HASMASKED;
@@ -779,7 +779,7 @@ void sep_set_ellipse(unsigned char *arr, int w, int h,
  *
  */
 
-int sep_windowed(sep_image *im,
+int sep_windowed(const sep_image *im,
                  double x, double y, double sig, int subpix, short inflag,
                  double *xout, double *yout, int *niter, short *flag)
 {
@@ -915,7 +915,7 @@ int sep_windowed(sep_image *im,
                     }
 
                   /* offset of this pixel from center */
-                  dx = ix - x; 
+                  dx = ix - x;
                   dy = iy - y;
 
                   /* weight by gaussian */

--- a/src/aperture.c
+++ b/src/aperture.c
@@ -558,7 +558,7 @@ int sep_sum_circann_multi(sep_image *im,
 
 
 /* for use in flux_radius */
-static double inverse(double xmax, double *y, int n, double ytarg)
+static double inverse(double xmax, const double *y, int n, double ytarg)
 {
   double step;
   int i;
@@ -586,7 +586,7 @@ static double inverse(double xmax, double *y, int n, double ytarg)
 int sep_flux_radius(sep_image *im,
                     double x, double y, double rmax, int id, 
                     int subpix, short inflag,
-                    double *fluxtot, double *fluxfrac, int n, double *r,
+                    const double *fluxtot, const double *fluxfrac, int n, double *r,
                     short *flag)
 {
   int status;

--- a/src/aperture.i
+++ b/src/aperture.i
@@ -1,5 +1,5 @@
 /*
-	Adding (void *) pointers is a GNU C extension, not part of standard C. 
+	Adding (void *) pointers is a GNU C extension, not part of standard C.
 	When compiling on Windows with MS Visual C compiler need to cast the
 	(void *) to something the size of one byte.
 */
@@ -9,7 +9,7 @@
   	#define MSVC_VOID_CAST
 #endif
 
-int APER_NAME(sep_image *im,
+int APER_NAME(const sep_image *im,
 	      double x, double y, APER_ARGS, int id, int subpix, short inflag,
 	      double *sum, double *sumerr, double *area, short *flag)
 {
@@ -53,7 +53,7 @@ int APER_NAME(sep_image *im,
 
   if (im->segmap && (status = get_converter(im->sdtype, &sconvert, &ssize)))
     return status;
-      
+
   /* get image noise */
   if (im->noise_type != SEP_NOISE_NONE)
     {
@@ -72,7 +72,7 @@ int APER_NAME(sep_image *im,
 
   /* get extent of box */
   APER_BOXEXTENT;
-  
+
   /* loop over rows in the box */
   for (iy=ymin; iy<ymax; iy++)
     {
@@ -85,7 +85,7 @@ int APER_NAME(sep_image *im,
 	maskt = MSVC_VOID_CAST im->mask + pos*msize;
       if (im->segmap)
   	segt = MSVC_VOID_CAST im->segmap + pos*ssize;
-  	
+
       /* loop over pixels in this row */
       for (ix=xmin; ix<xmax; ix++)
 	{
@@ -119,7 +119,7 @@ int APER_NAME(sep_image *im,
 	      else
 		/* definitely fully in aperture */
 		overlap = 1.0;
-	      
+
 	      pix = convert(datat);
 
 	      if (errisarray)
@@ -128,25 +128,25 @@ int APER_NAME(sep_image *im,
 		  if (errisstd)
 		    varpix *= varpix;
 		}
-              
+
               ismasked = 0;
 	      if (im->mask && (mconvert(maskt) > im->maskthresh))
 	        {
 	          ismasked = 1;
 	        }
-	      
-	      /* Segmentation image:  
-	           
-	           If `id` is negative, require segmented pixels within the 
+
+	      /* Segmentation image:
+
+	           If `id` is negative, require segmented pixels within the
 	           aperture.
-	           
+
 	           If `id` is positive, mask pixels with nonzero segment ids
 	           not equal to `id`.
-	           
-	      */ 
+
+	      */
 	      if (im->segmap)
   	        {
-  	          if (id > 0) 
+  	          if (id > 0)
   	            {
   	              if ((sconvert(segt) > 0.) & (sconvert(segt) != id))
   	                {
@@ -156,12 +156,12 @@ int APER_NAME(sep_image *im,
 	              if (sconvert(segt) != -1*id)
 	                {
 	                  ismasked = 1;
-	                }  	            
+	                }
   	            }
   	        }
-  	      
-	      if (ismasked > 0) 
-	      	{ 
+
+	      if (ismasked > 0)
+	      	{
 		  *flag |= SEP_APER_HASMASKED;
 		  maskarea += overlap;
 		}
@@ -174,7 +174,7 @@ int APER_NAME(sep_image *im,
 	      totarea += overlap;
 
 	    } /* closes "if pixel might be within aperture" */
-	  
+
 	  /* increment pointers by one element */
 	  datat += size;
 	  if (errisarray)

--- a/src/background.c
+++ b/src/background.c
@@ -251,7 +251,7 @@ void backstat(backstruct *backmesh,
   PIXTYPE	*buft,*wbuft;
   PIXTYPE       lcut,hcut;
   int		m,h,x,y, npix,wnpix, offset, lastbite;
-  
+
   h = bufsize/w;  /* height of background boxes in this row */
   bm = backmesh;
   offset = w - bw;
@@ -311,7 +311,7 @@ void backstat(backstruct *backmesh,
       mean = sigma = 0.0;
       npix = wnpix = 0;
       buft = buf;
-      
+
       /* do statistics for this mesh again, with cuts */
       if (wbuf)
 	{
@@ -355,9 +355,6 @@ void backstat(backstruct *backmesh,
       if (wbuf)
 	wbuf += bw;
     }
-
-  return;
-
 }
 
 /******************************** backhisto *********************************/
@@ -416,13 +413,12 @@ void backhisto(backstruct *backmesh,
 	  for (x=bw; x--;)
 	    {
 	      bin = (int)(*(buft++)/qscale + cste);
-	      
+
 	      if (bin>=0 && bin<nlevels)
 		(*(histo+bin))++;
 	    }
     }
-  return;
-}
+  }
 
 /******************************* backguess **********************************/
 /*
@@ -495,7 +491,7 @@ float backguess(backstruct *bkg, float *mean, float *sigma)
 			    bkg->qzero+(2.5*med-1.5*mea)*bkg->qscale
 			    :bkg->qzero+med*bkg->qscale))
     :bkg->qzero+mea*bkg->qscale;
-  
+
   *sigma = sig*bkg->qscale;
 
   return *mean;
@@ -511,7 +507,7 @@ int filterback(sep_bkg *bkg, int fw, int fh, double fthresh)
   float d2, d2min, med, val, sval;
   int i, j, px, py, np, nx, ny, npx, npx2, npy, npy2, dpx, dpy, x, y, nmin;
   int status;
-  
+
   status = RETURN_OK;
   bmask = smask = back2 = sigma2 = NULL;
 
@@ -682,7 +678,7 @@ int makebackspline(sep_bkg *bkg, float *map, float *dmap)
 
   return status;
 
- exit: 
+ exit:
   if (u) free(u);
   return status;
 }
@@ -866,7 +862,7 @@ int bkg_line_flt_internal(sep_bkg *bkg, float *values, float *dvalues, int y,
 	    }
 	  cdx = 1 - dx;
 
-	  *(line++) = (float)(cdx*(*blo+(cdx*cdx-1)**dblo) 
+	  *(line++) = (float)(cdx*(*blo+(cdx*cdx-1)**dblo)
 			      + dx*(*bhi+(dx*dx-1)**dbhi));
 
 	  if (i==nx)
@@ -889,7 +885,7 @@ int bkg_line_flt_internal(sep_bkg *bkg, float *values, float *dvalues, int y,
   return status;
 }
 
-int sep_bkg_line_flt(sep_bkg *bkg, int y, float *line) 
+int sep_bkg_line_flt(sep_bkg *bkg, int y, float *line)
 /* Interpolate background at line y (bicubic spline interpolation between
  * background map vertices) and save to line */
 {
@@ -913,11 +909,11 @@ int sep_bkg_line(sep_bkg *bkg, int y, void *line, int dtype)
 {
   array_writer write_array;
   int size, status;
-  float *tmpline; 
+  float *tmpline;
 
   if (dtype == SEP_TFLOAT)
     return sep_bkg_line_flt(bkg, y, (float *)line);
-   
+
   tmpline = NULL;
 
   status = get_array_writer(dtype, &write_array, &size);
@@ -941,11 +937,11 @@ int sep_bkg_rmsline(sep_bkg *bkg, int y, void *line, int dtype)
 {
   array_writer write_array;
   int size, status;
-  float *tmpline; 
+  float *tmpline;
 
   if (dtype == SEP_TFLOAT)
     return sep_bkg_rmsline_flt(bkg, y, (float *)line);
-   
+
   tmpline = NULL;
 
   status = get_array_writer(dtype, &write_array, &size);
@@ -984,7 +980,7 @@ int sep_bkg_array(sep_bkg *bkg, void *arr, int dtype)
 	  return status;
       return status;
     }
-  
+
   if ((status = get_array_writer(dtype, &write_array, &size)) != RETURN_OK)
     goto exit;
 
@@ -1022,7 +1018,7 @@ int sep_bkg_rmsarray(sep_bkg *bkg, void *arr, int dtype)
 	  return status;
       return status;
     }
-  
+
   if ((status = get_array_writer(dtype, &write_array, &size)) != RETURN_OK)
     goto exit;
 
@@ -1086,7 +1082,7 @@ int sep_bkg_subarray(sep_bkg *bkg, void *arr, int dtype)
     goto exit;
 
   for (y=0; y<bkg->h; y++, arrt+=(width*size))
-    { 
+    {
       if ((status = sep_bkg_line_flt(bkg, y, tmpline)) != RETURN_OK)
 	goto exit;
       subtract_array(tmpline, width, arrt);
@@ -1109,6 +1105,4 @@ void sep_bkg_free(sep_bkg *bkg)
       free(bkg->dsigma);
     }
   free(bkg);
-  
-  return;
 }

--- a/src/background.c
+++ b/src/background.c
@@ -54,7 +54,7 @@ float backguess(backstruct *bkg, float *mean, float *sigma);
 int makebackspline(sep_bkg *bkg, float *map, float *dmap);
 
 
-int sep_background(sep_image* image, int bw, int bh, int fw, int fh,
+int sep_background(const sep_image* image, int bw, int bh, int fw, int fh,
                    double fthresh, sep_bkg **bkg)
 {
   BYTE *imt, *maskt;

--- a/src/convolve.c
+++ b/src/convolve.c
@@ -36,7 +36,7 @@ f* GNU Lesser General Public License for more details.
  * convw, convh : width and height of conv
  * buf : output convolved line (buf->dw elements long)
  */
-int convolve(arraybuffer *buf, int y, float *conv, int convw, int convh,
+int convolve(arraybuffer *buf, int y, const float *conv, int convw, int convh,
              PIXTYPE *out)
 {
   int convw2, convn, cx, cy, i, dcx, y0;
@@ -121,7 +121,7 @@ int convolve(arraybuffer *buf, int y, float *conv, int convw, int convh,
  * (their `yoff` fields should be the same).
  */
 int matched_filter(arraybuffer *imbuf, arraybuffer *nbuf, int y,
-                   float *conv, int convw, int convh,
+                   const float *conv, int convw, int convh,
                    PIXTYPE *work, PIXTYPE *out, int noise_type)
 {
   int convw2, convn, cx, cy, i, dcx, y0;

--- a/src/extract.c
+++ b/src/extract.c
@@ -168,8 +168,8 @@ void apply_mask_line(arraybuffer *mbuf, arraybuffer *imbuf, arraybuffer *nbuf)
 }
 
 /****************************** extract **************************************/
-int sep_extract(sep_image *image, float thresh, int thresh_type,
-                int minarea, float *conv, int convw, int convh,
+int sep_extract(const sep_image *image, float thresh, int thresh_type,
+                int minarea, const float *conv, int convw, int convh,
 		int filter_type, int deblend_nthresh, double deblend_cont,
 		int clean_flag, double clean_param,
 		sep_catalog **catalog)

--- a/src/extract.h
+++ b/src/extract.h
@@ -26,8 +26,8 @@
                               /* (MEMORY_OBJSTACK in sextractor inputs) */
 #define CLEAN_MARGIN    0  /* replaces prefs.cleanmargin which was set based */
                            /* on stuff like apertures and vignet size */
-#define	MARGIN_SCALE   2.0 /* Margin / object height */ 
-#define	MARGIN_OFFSET  4.0 /* Margin offset (pixels) */ 
+#define	MARGIN_SCALE   2.0 /* Margin / object height */
+#define	MARGIN_OFFSET  4.0 /* Margin offset (pixels) */
 #define	MAXDEBAREA     3   /* max. area for deblending (must be >= 1)*/
 #define	MAXPICSIZE     1048576 /* max. image size in any dimension */
 
@@ -70,15 +70,16 @@ typedef struct
   PIXTYPE *midline;   /* "middle" line in buffer (at index bh/2) */
   PIXTYPE *lastline;  /* last line in buffer */
   array_converter readline;  /* function to read a data line into buffer */
-  int elsize;         /* size in bytes of one element in original data */ 
+  int elsize;         /* size in bytes of one element in original data */
   int yoff;           /* line index in original data corresponding to bufptr */
 } arraybuffer;
 
 
 /* globals */
-extern int plistexist_cdvalue, plistexist_thresh, plistexist_var;
-extern int plistoff_value, plistoff_cdvalue, plistoff_thresh, plistoff_var;
-extern int plistsize;
+extern _Thread_local int plistexist_cdvalue, plistexist_thresh, plistexist_var;
+extern _Thread_local int plistoff_value, plistoff_cdvalue, plistoff_thresh, plistoff_var;
+extern _Thread_local int plistsize;
+extern _Thread_local unsigned int randseed;
 
 typedef struct
 {
@@ -92,7 +93,7 @@ typedef struct
   int	   npix;       			/* "" in measured frame */
   int	   nzdwpix;			/* nb of zero-dweights around */
   int	   nzwpix;		       	/* nb of zero-weights inside */
-  
+
   /* position */
   int	   xpeak, ypeak;                     /* pos of brightest pix */
   int	   xcpeak,ycpeak;                    /* pos of brightest pix */
@@ -143,7 +144,7 @@ int  lutz(pliststruct *plistin,
 	  int *objrootsubmap, int subx, int suby, int subw,
 	  objstruct *objparent, objliststruct *objlist, int minarea);
 
-void update(infostruct *, infostruct *, pliststruct *);
+void update(infostruct *, infostruct *, const pliststruct *);
 
 int  allocdeblend(int);
 void freedeblend(void);
@@ -155,8 +156,8 @@ void mergeobjshallow(objstruct *, objstruct *);
 */
 int addobjdeep(int, objliststruct *, objliststruct *);
 
-int convolve(arraybuffer *buf, int y, float *conv, int convw, int convh,
+int convolve(arraybuffer *buf, int y, const float *conv, int convw, int convh,
              PIXTYPE *out);
 int matched_filter(arraybuffer *imbuf, arraybuffer *nbuf, int y,
-                   float *conv, int convw, int convh,
+                   const float *conv, int convw, int convh,
                    PIXTYPE *work, PIXTYPE *out, int noise_type);

--- a/src/sep.h
+++ b/src/sep.h
@@ -149,7 +149,7 @@ typedef struct {
  * - fw, fh = (3, 3)
  * - fthresh = 0.0
  */
-SEP_API int sep_background(sep_image *image,
+SEP_API int sep_background(const sep_image *image,
                    int bw, int bh,   /* size of a single background tile */
                    int fw, int fh,   /* filter size in tiles             */
                    double fthresh,   /* filter threshold                 */
@@ -218,11 +218,11 @@ SEP_API void sep_bkg_free(sep_bkg *bkg);
  * (the absolute threshold will be thresh*noise[i,j]).
  *
  */
-SEP_API int sep_extract(sep_image *image,
+SEP_API int sep_extract(const sep_image *image,
 		float thresh,         /* detection threshold           [1.5] */
                 int thresh_type,      /* threshold units    [SEP_THRESH_REL] */
 		int minarea,          /* minimum area in pixels          [5] */
-		float *conv,          /* convolution array (can be NULL)     */
+		const float *conv,    /* convolution array (can be NULL)     */
                                       /*               [{1 2 1 2 4 2 1 2 1}] */
 		int convw, int convh, /* w, h of convolution array     [3,3] */
                 int filter_type,      /* convolution (0) or matched (1)  [0] */
@@ -264,7 +264,7 @@ SEP_API void sep_catalog_free(sep_catalog *catalog);
  *        corrected. The area can differ from the exact area of a circle due
  *        to inexact subpixel sampling and intersection with array boundaries.
  */
-SEP_API int sep_sum_circle(sep_image *image,
+SEP_API int sep_sum_circle(const sep_image *image,
 		   double x,          /* center of aperture in x */
 		   double y,          /* center of aperture in y */
 		   double r,          /* radius of aperture */
@@ -277,17 +277,17 @@ SEP_API int sep_sum_circle(sep_image *image,
 		   short *flag);      /* OUTPUT: flags */
 
 
-SEP_API int sep_sum_circann(sep_image *image,
+SEP_API int sep_sum_circann(const sep_image *image,
                     double x, double y, double rin, double rout,
                     int id, int subpix, short inflags,
 		    double *sum, double *sumerr, double *area, short *flag);
 
-SEP_API int sep_sum_ellipse(sep_image *image,
+SEP_API int sep_sum_ellipse(const sep_image *image,
 		    double x, double y, double a, double b, double theta,
 		    double r, int id, int subpix, short inflags,
 		    double *sum, double *sumerr, double *area, short *flag);
 
-SEP_API int sep_sum_ellipann(sep_image *image,
+SEP_API int sep_sum_ellipann(const sep_image *image,
 		     double x, double y, double a, double b, double theta,
 		     double rin, double rout, int id, int subpix, short inflags,
 		     double *sum, double *sumerr, double *area, short *flag);
@@ -308,7 +308,7 @@ SEP_API int sep_sum_ellipann(sep_image *image,
              annulus (if mask not NULL).
  * flag:     Output flag (non-array).
  */
-SEP_API int sep_sum_circann_multi(sep_image *im,
+SEP_API int sep_sum_circann_multi(const sep_image *im,
 			  double x, double y, double rmax, int n, int id, int subpix,
                           short inflag,
 			  double *sum, double *sumvar, double *area,
@@ -328,7 +328,7 @@ SEP_API int sep_sum_circann_multi(sep_image *im,
  * r : (output) result array of length n.
  * flag : (output) scalar flag
  */
-SEP_API int sep_flux_radius(sep_image *im,
+SEP_API int sep_flux_radius(const sep_image *im,
 		    double x, double y, double rmax, int id, int subpix, short inflag,
 		    const double *fluxtot, const double *fluxfrac, int n,
 		    double *r, short *flag);
@@ -349,7 +349,7 @@ SEP_API int sep_flux_radius(sep_image *im,
  * SEP_APER_NONPOSITIVE - There was a nonpositive numerator or deminator.
  *                        kronrad = 0.
  */
-SEP_API int sep_kron_radius(sep_image *im, double x, double y,
+SEP_API int sep_kron_radius(const sep_image *im, double x, double y,
 		    double cxx, double cyy, double cxy, double r, int id,
 		    double *kronrad, short *flag);
 
@@ -366,7 +366,7 @@ SEP_API int sep_kron_radius(sep_image *im, double x, double y,
  * xout, yout : output center.
  * niter      : number of iterations used.
  */
-SEP_API int sep_windowed(sep_image *im,
+SEP_API int sep_windowed(const sep_image *im,
                  double x, double y, double sig, int subpix, short inflag,
                  double *xout, double *yout, int *niter, short *flag);
 

--- a/src/sep.h
+++ b/src/sep.h
@@ -330,7 +330,7 @@ SEP_API int sep_sum_circann_multi(sep_image *im,
  */
 SEP_API int sep_flux_radius(sep_image *im,
 		    double x, double y, double rmax, int id, int subpix, short inflag,
-		    double *fluxtot, double *fluxfrac, int n,
+		    const double *fluxtot, const double *fluxfrac, int n,
 		    double *r, short *flag);
 
 /* sep_kron_radius()
@@ -402,7 +402,7 @@ SEP_API void sep_ellipse_coeffs(double a, double b, double theta,
 /*----------------------- info & error messaging ----------------------------*/
 
 /* sep_version_string : library version (e.g., "0.2.0") */
-SEP_API extern char *sep_version_string;
+SEP_API extern const char *const sep_version_string;
 
 /* sep_get_errmsg()
  *

--- a/src/sepcore.h
+++ b/src/sepcore.h
@@ -33,7 +33,7 @@
 #define UNKNOWN_NOISE_TYPE  10
 
 #define	BIG 1e+30  /* a huge number (< biggest value a float can store) */
-#define	PI  3.1415926535898
+#define	PI  M_PI
 #define	DEG (PI/180.0)	    /* 1 deg in radians */
 
 typedef	int	      LONG;

--- a/src/util.c
+++ b/src/util.c
@@ -4,12 +4,12 @@
 *
 * All content except array comparison functions fqcmp() and fqmedian() is
 * distributed under an MIT license.
-* 
+*
 * Copyright 2014 SEP developers
 *
 * Array comparison functions fqcmp() and fqmedian() are distributed under an
 * LGPL license:
-* 
+*
 * Copyright 1993-2011 Emmanuel Bertin -- IAP/CNRS/UPMC
 * Copyright 2014 SEP developers
 *
@@ -24,8 +24,8 @@
 
 #define DETAILSIZE 512
 
-char *sep_version_string = "0.6.0";
-static char _errdetail_buffer[DETAILSIZE] = "";
+const char *const sep_version_string = "0.6.0";
+static _Thread_local char _errdetail_buffer[DETAILSIZE] = "";
 
 /****************************************************************************/
 /* data type conversion mechanics for runtime type conversion */
@@ -332,7 +332,7 @@ float fqmedian(float *ra, int n)
  * WARNING: input data are reordered! */
 {
   int dqcmp(const void *p1, const void *p2);
-  
+
   qsort(ra, n, sizeof(float), fqcmp);
   if (n<2)
     return *ra;


### PR DESCRIPTION
As mentioned in #81, currently the library is not thread-safe, that is, it can't even be used on multiple separate images in parallel due to the shared global mutable variables.

There are a couple of ways to fix this. I've mostly done refactoring in a separate branch to pass everything around via params, but that kind of a change is rather huge and harder to review for correctness.

So I took a different approach I mentioned in https://github.com/kbarbary/sep/issues/81#issuecomment-782900672, and instead went through all the statics and changed them depending on usage:

1. Into local function variables where they are initialized every time anyway - those clearly don't have to be `static`.
2. Into `const static` if it was a static that's been always initialised to the same constant value - there was just `initinfo` that fell into this category.
3. Into `_Atomic` if it's a global config - in particular `sub_object_limit` and `extract_pixstack` params. I believe there is no point in configuring those per-thread, so just left them as globals, but `_Atomic` ensures safe complete initialization in case of a race.
4. Finally, made all the other mutable statics `_Thread_local`, which ensures that none of the threads will override each others' data while storing temporary information about the image being processed.

Then, I used `clang-tidy` to:

1. Find and auto-mark all places where pointers can be `const` - this allows consumer to more easily reason about which data can be shared across images and/or threads, and which will be mutated internally by SEP and so needs to have separate copies per run.
2. Detect all non-thread-safe functions (clang-tidy can do this starting from LLVM 13). Such function was only `rand`, so I added a `_Thread_local` seed variable `randseed`, and switched those callsites to `rand_r(&randseed)`, making those thread-safe too.

Note that due to trimming of unnecessary spacing by clang-tidy and editors the diffs can look a bit more bloated, so I suggest to review the diff using "ignore whitespace changes" mode here: https://github.com/kbarbary/sep/compare/master...RReverser:simple-threadsafe?expand=1&w=1

Overall I think this is the least invasive change that should be relatively easy to review for correctness (and, of course, I checked that all the tests are passing), while at the same time ensures thread-safety throughout the codebase.

Fixes #81.