### PR TITLE
Reduce number of global thread-locals

### DIFF
--- a/src/deblend.c
+++ b/src/deblend.c
@@ -51,9 +51,6 @@ int belong(int, objliststruct *, int, objliststruct *);
 int *createsubmap(objliststruct *, int, int *, int *, int *, int *);
 int gatherup(objliststruct *, objliststruct *);
 
-static _Thread_local objliststruct *objlist=NULL;
-static _Thread_local short	     *son=NULL, *ok=NULL;
-
 /******************************** deblend ************************************/
 /*
 Divide a list of isophotal detections in several parts (deblending).
@@ -64,7 +61,7 @@ This can return two error codes: DEBLEND_OVERFLOW or MEMORY_ALLOC_ERROR
 */
 int deblend(objliststruct *objlistin, int l, objliststruct *objlistout,
 	    int deblend_nthresh, double deblend_mincont, int minarea,
-	    lutzbuffers *lutzbuf)
+	    deblendctx *ctx)
 {
   objstruct		*obj;
   objliststruct	debobjlist, debobjlist2;
@@ -80,6 +77,7 @@ int deblend(objliststruct *objlistin, int l, objliststruct *objlistout,
   xn = deblend_nthresh;
 
   /* reset global static objlist for deblending */
+  objliststruct *const objlist = ctx->objlist;
   memset(objlist, 0, (size_t)xn*sizeof(objliststruct));
 
   /* initialize local object lists */
@@ -110,7 +108,7 @@ int deblend(objliststruct *objlistin, int l, objliststruct *objlistout,
     goto exit;
 
   value0 = objlist[0].obj[0].fdflux*deblend_mincont;
-  ok[0] = (short)1;
+  ctx->ok[0] = (short)1;
   for (k=1; k<xn; k++)
     {
       /*------ Calculate threshold */
@@ -128,7 +126,7 @@ int deblend(objliststruct *objlistin, int l, objliststruct *objlistout,
       for (i=0; i<objlist[k-1].nobj; i++)
 	{
 	  status = lutz(objlistin->plist, submap, subx, suby, subw,
-			&objlist[k-1].obj[i], &debobjlist, minarea, lutzbuf);
+			&objlist[k-1].obj[i], &debobjlist, minarea, &ctx->lutz);
 	  if (status != RETURN_OK)
 	    goto exit;
 
@@ -146,16 +144,16 @@ int deblend(objliststruct *objlistin, int l, objliststruct *objlistout,
 		    goto exit;
 		  }
 		if (h>=nbm-1)
-		  if (!(son = (short *)
-			realloc(son,xn*nsonmax*(nbm+=16)*sizeof(short))))
+		  if (!(ctx->son = (short *)
+			realloc(ctx->son,xn*nsonmax*(nbm+=16)*sizeof(short))))
 		    {
 		      status = MEMORY_ALLOC_ERROR;
 		      goto exit;
 		    }
-		son[k-1+xn*(i+nsonmax*(h++))] = (short)m;
-		ok[k+xn*m] = (short)1;
+		ctx->son[k-1+xn*(i+nsonmax*(h++))] = (short)m;
+		ctx->ok[k+xn*m] = (short)1;
 	      }
-	  son[k-1+xn*(i+nsonmax*h)] = (short)-1;
+	  ctx->son[k-1+xn*(i+nsonmax*h)] = (short)-1;
 	}
     }
 
@@ -165,16 +163,16 @@ int deblend(objliststruct *objlistin, int l, objliststruct *objlistout,
       obj = objlist[k+1].obj;
       for (i=0; i<objlist[k].nobj; i++)
 	{
-	  for (m=h=0; (j=(int)son[k+xn*(i+nsonmax*h)])!=-1; h++)
+	  for (m=h=0; (j=(int)ctx->son[k+xn*(i+nsonmax*h)])!=-1; h++)
 	    {
 	      if (obj[j].fdflux - obj[j].thresh * obj[j].fdnpix > value0)
 		m++;
-	      ok[k+xn*i] &= ok[k+1+xn*j];
+	      ctx->ok[k+xn*i] &= ctx->ok[k+1+xn*j];
 	    }
 	  if (m>1)
 	    {
-	      for (h=0; (j=(int)son[k+xn*(i+nsonmax*h)])!=-1; h++)
-		if (ok[k+1+xn*j] &&
+	      for (h=0; (j=(int)ctx->son[k+xn*(i+nsonmax*h)])!=-1; h++)
+		if (ctx->ok[k+1+xn*j] &&
 		    obj[j].fdflux - obj[j].thresh * obj[j].fdnpix > value0)
 		  {
 		    objlist[k+1].obj[j].flag |= SEP_OBJ_MERGED;
@@ -182,12 +180,12 @@ int deblend(objliststruct *objlistin, int l, objliststruct *objlistout,
 		    if (status != RETURN_OK)
 		      goto exit;
 		  }
-	      ok[k+xn*i] = (short)0;
+	      ctx->ok[k+xn*i] = (short)0;
 	    }
 	}
     }
 
-  if (ok[0])
+  if (ctx->ok[0])
     status = addobjdeep(0, &debobjlist2, objlistout);
   else
     status = gatherup(&debobjlist2, objlistout);
@@ -220,16 +218,20 @@ int deblend(objliststruct *objlistin, int l, objliststruct *objlistout,
 /*
 Allocate the memory allocated by global pointers in refine.c
 */
-int allocdeblend(int deblend_nthresh)
+int allocdeblend(int deblend_nthresh, int w, int h, deblendctx *ctx)
 {
   int status=RETURN_OK;
-  QMALLOC(son, short,  deblend_nthresh*nsonmax*NBRANCH, status);
-  QMALLOC(ok, short,  deblend_nthresh*nsonmax, status);
-  QMALLOC(objlist, objliststruct, deblend_nthresh, status);
+  memset(ctx, 0, sizeof(deblendctx));
+  QMALLOC(ctx->son, short,  deblend_nthresh*nsonmax*NBRANCH, status);
+  QMALLOC(ctx->ok, short,  deblend_nthresh*nsonmax, status);
+  QMALLOC(ctx->objlist, objliststruct, deblend_nthresh, status);
+  status = lutzalloc(w, h, &ctx->lutz);
+  if (status != RETURN_OK)
+    goto exit;
 
   return status;
  exit:
-  freedeblend();
+  freedeblend(ctx);
   return status;
 }
 
@@ -237,14 +239,15 @@ int allocdeblend(int deblend_nthresh)
 /*
 Free the memory allocated by global pointers in refine.c
 */
-void freedeblend(void)
+void freedeblend(deblendctx *ctx)
 {
-  free(son);
-  son = NULL;
-  free(ok);
-  ok = NULL;
-  free(objlist);
-  objlist = NULL;
+  lutzfree(&ctx->lutz);
+  free(ctx->son);
+  ctx->son = NULL;
+  free(ctx->ok);
+  ctx->ok = NULL;
+  free(ctx->objlist);
+  ctx->objlist = NULL;
 }
 
 /********************************* gatherup **********************************/

--- a/src/deblend.c
+++ b/src/deblend.c
@@ -63,7 +63,8 @@ NOTE: Even if the object is not deblended, the output objlist threshold is
 This can return two error codes: DEBLEND_OVERFLOW or MEMORY_ALLOC_ERROR
 */
 int deblend(objliststruct *objlistin, int l, objliststruct *objlistout,
-	    int deblend_nthresh, double deblend_mincont, int minarea)
+	    int deblend_nthresh, double deblend_mincont, int minarea,
+	    lutzbuffers *lutzbuf)
 {
   objstruct		*obj;
   objliststruct	debobjlist, debobjlist2;
@@ -127,7 +128,7 @@ int deblend(objliststruct *objlistin, int l, objliststruct *objlistout,
       for (i=0; i<objlist[k-1].nobj; i++)
 	{
 	  status = lutz(objlistin->plist, submap, subx, suby, subw,
-			&objlist[k-1].obj[i], &debobjlist, minarea);
+			&objlist[k-1].obj[i], &debobjlist, minarea, lutzbuf);
 	  if (status != RETURN_OK)
 	    goto exit;
 

--- a/src/extract.c
+++ b/src/extract.c
@@ -55,7 +55,7 @@ size_t sep_get_extract_pixstack()
 int sortit(infostruct *info, objliststruct *objlist, int minarea,
 	   objliststruct *finalobjlist,
 	   int deblend_nthresh, double deblend_mincont, double gain,
-	   lutzbuffers *lutzbuf);
+	   deblendctx *deblendctx);
 void plistinit(int hasconv, int hasvar);
 void clean(objliststruct *objlist, double clean_param, int *survives);
 int convert_to_catalog(objliststruct *objlist, const int *survives,
@@ -202,7 +202,7 @@ int sep_extract(const sep_image *image, float thresh, int thresh_type,
   pixstatus         *psstack;
   char              errtext[512];
   sep_catalog       *cat;
-  lutzbuffers       lutzbuf;
+  deblendctx        deblendctx;
 
   status = RETURN_OK;
   pixel = NULL;
@@ -226,7 +226,7 @@ int sep_extract(const sep_image *image, float thresh, int thresh_type,
   pixvar = 0.0;
   pixsig = 0.0;
   isvarnoise = 0;
-  memset(&lutzbuf, 0, sizeof(lutzbuffers));
+  memset(&deblendctx, 0, sizeof(deblendctx));
 
   mem_pixstack = sep_get_extract_pixstack();
 
@@ -286,9 +286,7 @@ int sep_extract(const sep_image *image, float thresh, int thresh_type,
   QMALLOC(psstack, pixstatus, stacksize, status);
   QCALLOC(start, int, stacksize, status);
   QMALLOC(end, int, stacksize, status);
-  if ((status = lutzalloc(w, h, &lutzbuf)) != RETURN_OK)
-    goto exit;
-  if ((status = allocdeblend(deblend_nthresh)) != RETURN_OK)
+  if ((status = allocdeblend(deblend_nthresh, w, h, &deblendctx)) != RETURN_OK)
     goto exit;
 
   /* Initialize buffers for input array(s).
@@ -633,7 +631,7 @@ int sep_extract(const sep_image *image, float thresh, int thresh_type,
 			      status = sortit(&info[co], &objlist, minarea,
 					      finalobjlist,
 					      deblend_nthresh,deblend_cont,
-                                              image->gain, &lutzbuf);
+                                              image->gain, &deblendctx);
 			      if (status != RETURN_OK)
 				goto exit;
 			    }
@@ -703,12 +701,13 @@ int sep_extract(const sep_image *image, float thresh, int thresh_type,
   if (status != RETURN_OK) goto exit;
 
  exit:
-  free(finalobjlist->obj);
-  free(finalobjlist->plist);
-  free(finalobjlist);
-  freedeblend();
+  if (finalobjlist) {
+    free(finalobjlist->obj);
+    free(finalobjlist->plist);
+    free(finalobjlist);
+  }
+  freedeblend(&deblendctx);
   free(pixel);
-  lutzfree(&lutzbuf);
   free(info);
   free(store);
   free(marker);
@@ -753,7 +752,7 @@ build the object structure.
 int sortit(infostruct *info, objliststruct *objlist, int minarea,
 	   objliststruct *finalobjlist,
 	   int deblend_nthresh, double deblend_mincont, double gain,
-	   lutzbuffers *lutzbuf)
+	   deblendctx *deblendctx)
 {
   objliststruct	        objlistout, *objlist2;
   objstruct	obj;
@@ -778,7 +777,7 @@ int sortit(infostruct *info, objliststruct *objlist, int minarea,
   preanalyse(0, objlist);
 
   status = deblend(objlist, 0, &objlistout, deblend_nthresh, deblend_mincont,
-		   minarea, lutzbuf);
+		   minarea, deblendctx);
   if (status)
     {
       /* formerly, this wasn't a fatal error, so a flag was set for

--- a/src/extract.h
+++ b/src/extract.h
@@ -155,9 +155,15 @@ int  lutz(pliststruct *plistin,
 
 void update(infostruct *, infostruct *, const pliststruct *);
 
-int  allocdeblend(int);
-void freedeblend(void);
-int  deblend(objliststruct *, int, objliststruct *, int, double, int, lutzbuffers *);
+typedef struct {
+	objliststruct *objlist;
+	short *son, *ok;
+	lutzbuffers lutz;
+} deblendctx;
+
+int  allocdeblend(int deblend_nthresh, int w, int h, deblendctx *);
+void freedeblend(deblendctx *);
+int  deblend(objliststruct *, int, objliststruct *, int, double, int, deblendctx *);
 
 /*int addobjshallow(objstruct *, objliststruct *);
 int rmobjshallow(int, objliststruct *);

--- a/src/extract.h
+++ b/src/extract.h
@@ -138,17 +138,26 @@ int analysemthresh(int objnb, objliststruct *objlist, int minarea,
 void preanalyse(int, objliststruct *);
 void analyse(int, objliststruct *, int, double);
 
-int  lutzalloc(int, int);
-void lutzfree(void);
+typedef struct {
+	infostruct  *info, *store;
+	char	   *marker;
+	pixstatus   *psstack;
+	int         *start, *end, *discan;
+	int         xmin, ymin, xmax, ymax;
+} lutzbuffers;
+
+int  lutzalloc(int, int, lutzbuffers *);
+void lutzfree(lutzbuffers *);
 int  lutz(pliststruct *plistin,
 	  int *objrootsubmap, int subx, int suby, int subw,
-	  objstruct *objparent, objliststruct *objlist, int minarea);
+	  objstruct *objparent, objliststruct *objlist, int minarea,
+	  lutzbuffers *buffers);
 
 void update(infostruct *, infostruct *, const pliststruct *);
 
 int  allocdeblend(int);
 void freedeblend(void);
-int  deblend(objliststruct *, int, objliststruct *, int, double, int);
+int  deblend(objliststruct *, int, objliststruct *, int, double, int, lutzbuffers *);
 
 /*int addobjshallow(objstruct *, objliststruct *);
 int rmobjshallow(int, objliststruct *);


### PR DESCRIPTION
Now that #109 transformed global statics into thread-locals, it's a lot easier to go one step further and transform them into local variables.

This restructures:
 - `lutz.c` thread-locals used for its buffers are transformed into a struct type `lutzbuffers`.
   Functions `lutzalloc()`, `lutzfree()` and `lutz()` itself to accept `lutzbuffers *` instead of operating on globals.
 - `deblend.c` thread-locals are transformed into a struct type `deblendctx`. Additionally, it now incorporates the new `lutzbuffers` type from above as part of `deblendctx` type since logically it's just a part of it.
    Now `allocdeblend()` both calls `lutzalloc()` and initializes deblend-specific vars, and `freedeblend()` calls `lutzfree()` in addition to its own free actions.
    `allocdeblend()`, `freedeblend()` and `deblend()` itself all now accept a `deblendctx *` instead of operating on globals.
 - `sortit` in `extract.c` now also accepts `deblendctx *` and passes it to `deblend()`.
 - Finally, `sep_extract` - the root public API function - just contains a function-local `deblendctx` variable and allocs/frees it via `allocdeblend()` / `freedeblend()` respectively.

After this change, the only global thread-locals remaining and `plist*` variables, but those are much trickier to remove cleanly because several different files rely on them either directly or via `PLIST*` macros. For now I'm just leaving them as-is.