### PR TITLE
Added back in a loop over objects in the deblending.

### DIFF
--- a/src/extract.c
+++ b/src/extract.c
@@ -776,7 +776,7 @@ int sortit(infostruct *info, objliststruct *objlist, int minarea,
 
   preanalyse(0, objlist);
 
-  status = deblend(objlist, 0, &objlistout, deblend_nthresh, deblend_mincont,
+  status = deblend(objlist, &objlistout, deblend_nthresh, deblend_mincont,
 		   minarea, deblendctx);
   if (status)
     {

--- a/src/extract.h
+++ b/src/extract.h
@@ -162,7 +162,7 @@ typedef struct {
 
 int  allocdeblend(int deblend_nthresh, int w, int h, deblendctx *);
 void freedeblend(deblendctx *);
-int  deblend(objliststruct *, int, objliststruct *, int, double, int, deblendctx *);
+int  deblend(objliststruct *, objliststruct *, int, double, int, deblendctx *);
 
 /*int addobjshallow(objstruct *, objliststruct *);
 int rmobjshallow(int, objliststruct *);


### PR DESCRIPTION
@kbarbary It looks like there is a loop over objects that is missing in SEP vs source extractor. I've attempted to put it back here. It seems to help deblending for really crowded fields. What do you think?