### PR TITLE
add python 3.10 and aarch64 support, update tools

### DIFF
--- a/.github/workflows/build-wheels-upload-pypi.yml
+++ b/.github/workflows/build-wheels-upload-pypi.yml
@@ -62,37 +62,62 @@ jobs:
     # done with the help of the `cibuildwheel` package.
     #
     # The wheels are built for Windows, Linux and MacOS and the python versions
-    # 3.5 - 3.9.
+    # 3.5 - 3.10.
     #
     # The three operating system could be done in parallel.
 
     runs-on: ${{ matrix.os }}
+    env:
+      CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
+      
     strategy:
-      max-parallel: 3
+      max-parallel: 4
       matrix:
         python-version: [3.9]
         os: [windows-latest, macos-latest, ubuntu-latest]
+        include:
+          - os: ubuntu-20.04
+            cibw_archs: "aarch64"
 
     steps:
+      - name: setup QEMU
+        if: matrix.cibw_archs == 'aarch64'
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm64
+
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==1.7.4
+        run: python -m pip install cibuildwheel
 
       - name: Build wheels
+        if: matrix.cibw_archs == 'aarch64'
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_BUILD: "cp3*"
-          # CIBW_SKIP: "cp35-* cp36-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_MANYLINUX_I686_IMAGE: manylinux2014
           CIBW_BUILD_VERBOSITY: 1
+          CIBW_SKIP: '*-musllinux_*'
+          CIBW_ARCHS_LINUX: "aarch64"
+
+      - name: Build wheels
+        if: matrix.cibw_archs != 'aarch64'
+        run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_BUILD: "cp3*"
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_MANYLINUX_I686_IMAGE: manylinux2014
+          CIBW_BUILD_VERBOSITY: 1
+          CIBW_SKIP: '*-musllinux_*'
+          CIBW_ARCHS_LINUX: "auto"
 
       - name: Show files
         run: ls -lh wheelhouse


### PR DESCRIPTION
Hi Kyle,
since some time ago we added the actions and wheel build to sep. I still use this package in my application. As time moves on, python 3.10 and arm come more and more necessary. So this pull request tries to add support for python 3.10, macOS M1 and aarch64 support. In my test environment all wheels are build. Please check if that changes are appropriate for you and if you also might publish a minor release (e.g. 1.2.1) just for adding this support.
Michel