### PR TITLE
Adding support python 3.12

### DIFF
--- a/.github/workflows/build-wheels-upload-pypi.yml
+++ b/.github/workflows/build-wheels-upload-pypi.yml
@@ -27,18 +27,20 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: install_python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: 3.12
 
       # For the build, sep needs numpy and cython and we add twine and wheel
       # for better testing and checking.
+      - name: Update PIP
+        run: python -m pip install pip --upgrade
 
       - name: Install dependencies
-        run: python -m pip install twine numpy wheel cython
+        run: python -m pip install setuptools twine numpy wheel cython
 
       - name: Build sdist
         run: python setup.py sdist
@@ -51,7 +53,7 @@ jobs:
         run: twine check dist/*
 
       - name: Upload sdist
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: dist
           path: dist/*.tar.gz
@@ -61,7 +63,7 @@ jobs:
     # Second the wheels are build for different OS and python versions. This is
     # done with the help of the `cibuildwheel` package.
     #
-    # The wheels are built for Windows, Linux and MacOS and the python versions
+    # The wheels are built for Windows, Linux and macOS and the python versions
     # 3.5 - 3.10.
     #
     # The three operating system could be done in parallel.
@@ -73,16 +75,17 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.9]
+        python-version: [3.12]
         os: [windows-latest, macos-latest, ubuntu-latest]
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             cibw_archs: "aarch64"
-
+            python-version: 3.12
+  
     steps:
       - name: setup QEMU
         if: matrix.cibw_archs == 'aarch64'
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64
 
@@ -90,7 +93,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -124,7 +127,7 @@ jobs:
         shell: bash
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: dist
           path: ./wheelhouse/*.whl
@@ -144,15 +147,17 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
 
     steps:
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
+      with:
+        python-version: 3.12
 
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: dist
         path: dist
 
     - name: upload_to_pypi
-      uses: pypa/gh-action-pypi-publish@v1.4.1
+      uses: pypa/gh-action-pypi-publish@v1.8.10
       with:
         user: __token__
         password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/build-wheels-upload-pypi.yml
+++ b/.github/workflows/build-wheels-upload-pypi.yml
@@ -73,7 +73,7 @@ jobs:
       CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
       
     strategy:
-      max-parallel: 4
+      max-parallel: 8
       matrix:
         python-version: [3.12]
         os: [windows-latest, macos-latest, ubuntu-latest]
@@ -100,27 +100,49 @@ jobs:
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel
 
-      - name: Build wheels
+      - name: Build wheels until 3.11
         if: matrix.cibw_archs == 'aarch64'
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: "cp3*"
+          CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_MANYLINUX_I686_IMAGE: manylinux2014
           CIBW_BUILD_VERBOSITY: 1
           CIBW_SKIP: '*-musllinux_*'
           CIBW_ARCHS_LINUX: "aarch64"
 
-      - name: Build wheels
+      - name: Build wheels until 3.11
         if: matrix.cibw_archs != 'aarch64'
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: "cp3*"
+          CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_MANYLINUX_I686_IMAGE: manylinux2014
           CIBW_BUILD_VERBOSITY: 1
           CIBW_SKIP: '*-musllinux_*'
           CIBW_ARCHS_LINUX: "auto"
+
+      - name: Build wheels from 3.12
+        if: matrix.cibw_archs == 'aarch64'
+        run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_BUILD: "cp312-*"
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_MANYLINUX_I686_IMAGE: manylinux2014
+          CIBW_BUILD_VERBOSITY: 1
+          CIBW_SKIP: '*-musllinux_*'
+          CIBW_ARCHS_LINUX: "aarch64"
+
+      - name: Build wheels from 3.12
+        if: matrix.cibw_archs != 'aarch64'
+        run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_BUILD: "cp312-*"
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_MANYLINUX_I686_IMAGE: manylinux2014
+          CIBW_BUILD_VERBOSITY: 1
+          CIBW_SKIP: '*-musllinux_*'
+          CIBW_ARCHS_LINUX: "x86_64"
 
       - name: Show files
         run: ls -lh wheelhouse


### PR DESCRIPTION
Hi Kay,
long time no contact. I added support for python 3.12 and updated the actions used. In moving for 3.12, I had to remove the wheel support for 32bit on linux from 3.12 ongoing. Nevertheless, older python version still get 32bit wheels as in the past.
If you don't mind, please have a look to the updates and trigger a new build after your review.
Michel